### PR TITLE
Optional workflow features should be optional

### DIFF
--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -499,7 +499,7 @@ jobs:
   #
   # See: https://github.com/rust-embedded/cross#docker-in-docker
   cross:
-    # if: ${{ needs.prepare.outputs.cross_build_rules != '[]' }}
+    if: ${{ needs.prepare.outputs.cross_build_rules != '[]' }}
     needs: prepare
     runs-on: ubuntu-20.04
     strategy:
@@ -549,7 +549,7 @@ jobs:
   #   - https://github.com/mmstick/cargo-deb
   #   - https://github.com/cat-in-136/cargo-generate-rpm
   pkg:
-    if: ${{ needs.prepare.outputs.package_build_rules != '{}' }}
+    # if: ${{ needs.prepare.outputs.package_build_rules != '{}' }}
     needs: [cross, prepare]
     runs-on: ubuntu-latest
     # Build on the platform we are targeting in order to avoid https://github.com/rust-lang/rust/issues/57497.

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -133,7 +133,7 @@ on:
         description: "A JSON array of cross-compilation targets, e.g. [ 'arm-unknown-linux-musleabihf', 'armv7-unknown-linux-musleabihf' ]"
         required: false
         type: string
-        default: '["dummy"]'
+        default: '["no-cross"]'
       cross_build_rules_path:
         description: "A relative path within the repository clone to a file containing a `cross_rules` array in YAML format. Each item in the array must be one of: https://github.com/cross-rs/cross#supported-targets"
         required: false
@@ -333,7 +333,7 @@ jobs:
           echo "Cross build rules:"
           echo "============================================================================="
           JSON='${{ toJSON(fromJSON(steps.select_inputs.outputs.cross_build_rules)) }}'
-          if [[ "${JSON}" != "[]" && "${JSON}" != '["dummy"]' ]]; then
+          if [[ "${JSON}" != "[]" && "${JSON}" != '["no-cross"]' ]]; then
             echo ${JSON} | jq
           else
             echo None
@@ -508,18 +508,18 @@ jobs:
     - name: Verify inputs
       id: verify
       run: |
-        if [[ "${{ matrix.target }}" == "dummy" ]]; then
-          echo "::set-output name=dummy::true"
+        if [[ "${{ matrix.target }}" == "no-cross" ]]; then
+          echo "::set-output name=no-cross::true"
         else
-          echo "::set-output name=dummy::false"
+          echo "::set-output name=no-cross::false"
         fi
 
     - name: Checkout repository
-      if: ${{ steps.verify.outputs.dummy == 'false' }}
+      if: ${{ steps.verify.outputs.no-cross == 'false' }}
       uses: actions/checkout@v2
 
     - name: Cache cargo cross
-      if: ${{ steps.verify.outputs.dummy == 'false' }}
+      if: ${{ steps.verify.outputs.no-cross == 'false' }}
       uses: actions/cache@v3
       with:
         path: |
@@ -528,7 +528,7 @@ jobs:
         key: ${{ matrix.target }}-cargo-cross
 
     - name: Cross compile
-      if: ${{ steps.verify.outputs.dummy == 'false' }}
+      if: ${{ steps.verify.outputs.no-cross == 'false' }}
       uses: actions-rs/cargo@v1
       with:
         use-cross: true
@@ -536,7 +536,7 @@ jobs:
         args: --locked --release --target ${{ matrix.target }} ${{ inputs.cross_build_args }}
 
     - name: Tar the set of created binaries to upload
-      if: ${{ steps.verify.outputs.dummy == 'false' }}
+      if: ${{ steps.verify.outputs.no-cross == 'false' }}
       run: |
         rm -f bins.tar
         find target/${{ matrix.target }}/release/ -maxdepth 1 -type f -executable | xargs tar vpcf bins.tar
@@ -548,7 +548,7 @@ jobs:
     # artifacts to be packaged by the scripts that upload to packages.nlnetlabs.nl we prefix the artifact name with
     # `tmp-` which will be ignored by packages.nlnetlabs.nl scripts.
     - name: Upload built binaries
-      if: ${{ steps.verify.outputs.dummy == 'false' }}
+      if: ${{ steps.verify.outputs.no-cross == 'false' }}
       uses: actions/upload-artifact@v3
       with:
         name: tmp-cross-binaries-${{ matrix.target }}

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -515,11 +515,11 @@ jobs:
         fi
 
     - name: Checkout repository
-      if: ${{ steps.verify.dummy == 'false' }}
+      if: ${{ steps.verify.dummy == 'true' }}
       uses: actions/checkout@v2
 
     - name: Cache cargo cross
-      if: ${{ steps.verify.dummy == 'false' }}
+      if: ${{ steps.verify.dummy == 'true' }}
       uses: actions/cache@v3
       with:
         path: |
@@ -528,7 +528,7 @@ jobs:
         key: ${{ matrix.target }}-cargo-cross
 
     - name: Cross compile
-      if: ${{ steps.verify.dummy == 'false' }}
+      if: ${{ steps.verify.dummy == 'true' }}
       uses: actions-rs/cargo@v1
       with:
         use-cross: true
@@ -536,7 +536,7 @@ jobs:
         args: --locked --release --target ${{ matrix.target }} ${{ inputs.cross_build_args }}
 
     - name: Tar the set of created binaries to upload
-      if: ${{ steps.verify.dummy == 'false' }}
+      if: ${{ steps.verify.dummy == 'true' }}
       run: |
         rm -f bins.tar
         find target/${{ matrix.target }}/release/ -maxdepth 1 -type f -executable | xargs tar vpcf bins.tar
@@ -548,7 +548,7 @@ jobs:
     # artifacts to be packaged by the scripts that upload to packages.nlnetlabs.nl we prefix the artifact name with
     # `tmp-` which will be ignored by packages.nlnetlabs.nl scripts.
     - name: Upload built binaries
-      if: ${{ steps.verify.dummy == 'false' }}
+      if: ${{ steps.verify.dummy == 'true' }}
       uses: actions/upload-artifact@v3
       with:
         name: tmp-cross-binaries-${{ matrix.target }}

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -298,7 +298,7 @@ jobs:
           from: yaml
           to: json
 
-      - name: Pre-process rule inputs
+      - name: Pre-process rules
         id: pre_process_rules
         run: |
           if [[ "${{ inputs.cross_build_rules_path }}" != "" ]]; then
@@ -331,7 +331,7 @@ jobs:
           fi
           echo "::set-output name=package_test_rules::${JSON}"
 
-      - name: Print the loaded rules
+      - name: Print rules
         # Disable default use of bash -x for easier to read output in the log
         shell: bash
         run: |

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -515,11 +515,11 @@ jobs:
         fi
 
     - name: Checkout repository
-      if: ${{ steps.verify.dummy == 'true' }}
+      if: ${{ steps.verify.outputs.dummy == 'false' }}
       uses: actions/checkout@v2
 
     - name: Cache cargo cross
-      if: ${{ steps.verify.dummy == 'true' }}
+      if: ${{ steps.verify.outputs.dummy == 'false' }}
       uses: actions/cache@v3
       with:
         path: |
@@ -528,7 +528,7 @@ jobs:
         key: ${{ matrix.target }}-cargo-cross
 
     - name: Cross compile
-      if: ${{ steps.verify.dummy == 'true' }}
+      if: ${{ steps.verify.outputs.dummy == 'false' }}
       uses: actions-rs/cargo@v1
       with:
         use-cross: true
@@ -536,7 +536,7 @@ jobs:
         args: --locked --release --target ${{ matrix.target }} ${{ inputs.cross_build_args }}
 
     - name: Tar the set of created binaries to upload
-      if: ${{ steps.verify.dummy == 'true' }}
+      if: ${{ steps.verify.outputs.dummy == 'false' }}
       run: |
         rm -f bins.tar
         find target/${{ matrix.target }}/release/ -maxdepth 1 -type f -executable | xargs tar vpcf bins.tar
@@ -548,7 +548,7 @@ jobs:
     # artifacts to be packaged by the scripts that upload to packages.nlnetlabs.nl we prefix the artifact name with
     # `tmp-` which will be ignored by packages.nlnetlabs.nl scripts.
     - name: Upload built binaries
-      if: ${{ steps.verify.dummy == 'true' }}
+      if: ${{ steps.verify.outputs.dummy == 'false' }}
       uses: actions/upload-artifact@v3
       with:
         name: tmp-cross-binaries-${{ matrix.target }}

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -365,7 +365,12 @@ jobs:
           echo "============================================================================="
           echo "Packages test rules:"
           echo "============================================================================="
+
           JSON='${{ toJSON(fromJSON(steps.select_inputs.outputs.package_test_rules)) }}'
+
+          # Exclude debian:stretch because the LXC image is no longer available
+          JSON=$(echo ${JSON} | jq -c '. + {exclude: { image: "debian:stretch" }}')
+
           if [[ "${JSON}" != "{}" ]]; then
             echo ${JSON} | jq
           else

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -133,7 +133,7 @@ on:
         description: "A JSON array of cross-compilation targets, e.g. [ 'arm-unknown-linux-musleabihf', 'armv7-unknown-linux-musleabihf' ]"
         required: false
         type: string
-        default: '[]'
+        default: '["dummy"]'
       cross_build_rules_path:
         description: "A relative path within the repository clone to a file containing a `cross_rules` array in YAML format. Each item in the array must be one of: https://github.com/cross-rs/cross#supported-targets"
         required: false
@@ -333,7 +333,7 @@ jobs:
           echo "Cross build rules:"
           echo "============================================================================="
           JSON='${{ toJSON(fromJSON(steps.select_inputs.outputs.cross_build_rules)) }}'
-          if [[ "${JSON}" != "[]" ]]; then
+          if [[ "${JSON}" != "[]" && "${JSON}" != '["dummy"]' ]]; then
             echo ${JSON} | jq
           else
             echo None
@@ -499,17 +499,27 @@ jobs:
   #
   # See: https://github.com/rust-embedded/cross#docker-in-docker
   cross:
-    if: ${{ needs.prepare.outputs.cross_build_rules != '[]' }}
     needs: prepare
     runs-on: ubuntu-20.04
     strategy:
       matrix:
         target: ${{ fromJSON(needs.prepare.outputs.cross_build_rules) }}
     steps:
+    - name: Verify inputs
+      id: verify
+      run: |
+        if [[ "${{ matrix.target}" == "dummy" ]]; then
+          echo "::set-output name=dummy::true"
+        else
+          echo "::set-output name=dummy::false"
+        fi
+
     - name: Checkout repository
+      if: ${{ steps.verify.dummy == 'false' }}
       uses: actions/checkout@v2
 
     - name: Cache cargo cross
+      if: ${{ steps.verify.dummy == 'false' }}
       uses: actions/cache@v3
       with:
         path: |
@@ -518,6 +528,7 @@ jobs:
         key: ${{ matrix.target }}-cargo-cross
 
     - name: Cross compile
+      if: ${{ steps.verify.dummy == 'false' }}
       uses: actions-rs/cargo@v1
       with:
         use-cross: true
@@ -525,6 +536,7 @@ jobs:
         args: --locked --release --target ${{ matrix.target }} ${{ inputs.cross_build_args }}
 
     - name: Tar the set of created binaries to upload
+      if: ${{ steps.verify.dummy == 'false' }}
       run: |
         rm -f bins.tar
         find target/${{ matrix.target }}/release/ -maxdepth 1 -type f -executable | xargs tar vpcf bins.tar
@@ -536,15 +548,11 @@ jobs:
     # artifacts to be packaged by the scripts that upload to packages.nlnetlabs.nl we prefix the artifact name with
     # `tmp-` which will be ignored by packages.nlnetlabs.nl scripts.
     - name: Upload built binaries
+      if: ${{ steps.verify.dummy == 'false' }}
       uses: actions/upload-artifact@v3
       with:
         name: tmp-cross-binaries-${{ matrix.target }}
         path: bins.tar
-
-  cross-bridge:
-    if: ${{ always() }}
-    needs: cross
-    runs-on: ubuntu-20.04
 
   # -------------------------------------------------------------------------------------------------------------------
   # Job: 'pkg'
@@ -555,7 +563,7 @@ jobs:
   #   - https://github.com/cat-in-136/cargo-generate-rpm
   pkg:
     if: ${{ needs.prepare.outputs.package_build_rules != '{}' }}
-    needs: [cross-bridge, prepare]
+    needs: [cross, prepare]
     runs-on: ubuntu-latest
     # Build on the platform we are targeting in order to avoid https://github.com/rust-lang/rust/issues/57497.
     # Specifying container causes all of the steps in this job to run inside a Docker container (which is why the
@@ -1199,7 +1207,7 @@ jobs:
   # in the docker-manifest job below.
   docker:
     if: ${{ needs.prepare.outputs.docker_build_rules != '{}' }}
-    needs: [cross-bridge, prepare]
+    needs: [cross, prepare]
     runs-on: ubuntu-20.04
     strategy:
       fail-fast: false

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -327,7 +327,7 @@ jobs:
 
           # Exclude debian:stretch because the LXC image is no longer available
           JSON=$(echo ${JSON} | jq 'del(.image[] | select(. == "debian:stretch"))' | jq -c)
-          echo '::set-output name=package_test_rules::${JSON}'
+          echo "::set-output name=package_test_rules::${JSON}"
 
       - name: Print the loaded rules
         # Disable default use of bash -x for easier to read output in the log
@@ -369,7 +369,6 @@ jobs:
           echo "============================================================================="
           echo "Packages test rules:"
           echo "============================================================================="
-
           JSON='${{ toJSON(fromJSON(steps.select_inputs.outputs.package_test_rules)) }}'
           if [[ "${JSON}" != "{}" ]]; then
             echo ${JSON} | jq

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -300,25 +300,25 @@ jobs:
       - name: Prefer inline rules over loaded rules
         id: select_inputs
         run: |
-          if [[ "${{ inputs.cross_build_rules }}" != "" ]]; then
+          if [[ "${{ inputs.cross_build_rules }}" != "[]" ]]; then
             echo '::set-output name=cross_build_rules::${{ inputs.cross_build_rules }}'
           else
             echo '::set-output name=cross_build_rules::${{ steps.transform_cross_build_rules_file.outputs.data }}'
           fi
 
-          if [[ "${{ inputs.docker_build_rules }}" != "" ]]; then
+          if [[ "${{ inputs.docker_build_rules }}" != "{}" ]]; then
             echo '::set-output name=docker_build_rules::${{ inputs.docker_build_rules }}'
           else
             echo '::set-output name=docker_build_rules::${{ steps.transform_docker_build_rules_file.outputs.data }}'
           fi
 
-          if [[ "${{ inputs.package_build_rules }}" != "" ]]; then
+          if [[ "${{ inputs.package_build_rules }}" != "{}" ]]; then
             echo '::set-output name=package_build_rules::${{ inputs.package_build_rules }}'
           else
             echo '::set-output name=package_build_rules::${{ steps.transform_package_build_rules_file.outputs.data }}'
           fi
 
-          if [[ "${{ inputs.package_test_rules }}" != "" ]]; then
+          if [[ "${{ inputs.package_test_rules }}" != "{}" ]]; then
             echo '::set-output name=package_test_rules::${{ inputs.package_test_rules }}'
           else
             echo '::set-output name=package_test_rules::${{ steps.transform_package_test_rules_file.outputs.data }}'

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -331,25 +331,41 @@ jobs:
           echo "============================================================================="
           echo "Cross build rules:"
           echo "============================================================================="
-          echo '${{ toJSON(fromJSON(steps.select_inputs.outputs.cross_build_rules)) }}'
+          if [[ "${{ steps.select_inputs.outputs.cross_build_rules }}" != "" ]]; then
+            echo '${{ toJSON(fromJSON(steps.select_inputs.outputs.cross_build_rules)) }}'
+          else
+            echo None
+          fi
 
           echo
           echo "============================================================================="
           echo "Docker build rules:"
           echo "============================================================================="
-          echo '${{ toJSON(fromJSON(steps.select_inputs.outputs.docker_build_rules)) }}'
+          if [[ "${{ steps.select_inputs.outputs.docker_build_rules }}" != "" ]]; then
+            echo '${{ toJSON(fromJSON(steps.select_inputs.outputs.docker_build_rules)) }}'
+          else
+            echo None
+          fi
 
           echo
           echo "============================================================================="
           echo "Package build rules:"
           echo "============================================================================="
-          echo '${{ toJSON(fromJSON(steps.select_inputs.outputs.package_build_rules)) }}'
+          if [[ "${{ steps.select_inputs.outputs.package_build_rules }}" != "" ]]; then
+            echo '${{ toJSON(fromJSON(steps.select_inputs.outputs.package_build_rules)) }}'
+          else
+            echo None
+          fi
 
           echo
           echo "============================================================================="
           echo "Packages test rules:"
           echo "============================================================================="
-          echo '${{ toJSON(fromJSON(steps.select_inputs.outputs.package_test_rules)) }}'
+          if [[ "${{ steps.select_inputs.outputs.package_test_rules }}" != "" ]]; then
+            echo '${{ toJSON(fromJSON(steps.select_inputs.outputs.package_test_rules)) }}'
+          else
+            echo None
+          fi
 
       - name: Verify inputs
         if: ${{ inputs.rpm_scriptlets_path != '' }}

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -300,28 +300,28 @@ jobs:
       - name: Prefer inline rules over loaded rules
         id: select_inputs
         run: |
-          if [[ "${{ inputs.cross_build_rules }}" != "[]" ]]; then
-            echo '::set-output name=cross_build_rules::${{ inputs.cross_build_rules }}'
-          else
+          if [[ "${{ inputs.cross_build_rules_path }}" != "" ]]; then
             echo '::set-output name=cross_build_rules::${{ steps.transform_cross_build_rules_file.outputs.data }}'
+          else
+            echo '::set-output name=cross_build_rules::${{ inputs.cross_build_rules }}'
           fi
 
-          if [[ "${{ inputs.docker_build_rules }}" != "{}" ]]; then
-            echo '::set-output name=docker_build_rules::${{ inputs.docker_build_rules }}'
-          else
+          if [[ "${{ inputs.docker_build_rules_path }}" != "" ]]; then
             echo '::set-output name=docker_build_rules::${{ steps.transform_docker_build_rules_file.outputs.data }}'
+          else
+            echo '::set-output name=docker_build_rules::${{ inputs.docker_build_rules }}'
           fi
 
-          if [[ "${{ inputs.package_build_rules }}" != "{}" ]]; then
-            echo '::set-output name=package_build_rules::${{ inputs.package_build_rules }}'
-          else
+          if [[ "${{ inputs.package_build_rules_path }}" != "" ]]; then
             echo '::set-output name=package_build_rules::${{ steps.transform_package_build_rules_file.outputs.data }}'
+          else
+            echo '::set-output name=package_build_rules::${{ inputs.package_build_rules }}'
           fi
 
-          if [[ "${{ inputs.package_test_rules }}" != "{}" ]]; then
-            echo '::set-output name=package_test_rules::${{ inputs.package_test_rules }}'
-          else
+          if [[ "${{ inputs.package_test_rules_path }}" != "" ]]; then
             echo '::set-output name=package_test_rules::${{ steps.transform_package_test_rules_file.outputs.data }}'
+          else
+            echo '::set-output name=package_test_rules::${{ inputs.package_test_rules }}'
           fi
 
       - name: Print the loaded rules

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -177,7 +177,7 @@ on:
         description: "A GitHub Actions matrix in JSON format with platform, shortname, crosstarget (required if mode is copy), mode (optional: build or copy) and cargo_args (optional) fields."
         required: false
         type: string
-        default: ''
+        default: '{}'
       docker_build_rules_path:
         description: "A relative path within the repository clone to a file containing a `docker_build_rules` matrix in YAML format."
         required: false

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -327,7 +327,12 @@ jobs:
 
           # Exclude debian:stretch because the LXC image is no longer available
           if [[ "${JSON}" != "{}" ]]; then
-            JSON=$(echo ${JSON} | jq 'del(.image[] | select(. == "debian:stretch"))' | jq -c)
+            CONTROL_JSON=$(echo ${JSON} | jq 'del(.image[] | select(. == "i-dont-exist"))' | jq -c)
+            MODIFIED_JSON=$(echo ${JSON} | jq 'del(.image[] | select(. == "debian:stretch"))' | jq -c)
+            if [[ "${CONTROL_JSON}" != "${MODIFIED_JSON}" ]]; then
+              echo "::warning::Removed debian:stretch from package_test_rules because the LXC image no longer exists"
+              JSON="${MODIFIED_JSON}"
+            fi
           fi
           echo "::set-output name=package_test_rules::${JSON}"
 

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -326,7 +326,9 @@ jobs:
           fi
 
           # Exclude debian:stretch because the LXC image is no longer available
-          JSON=$(echo ${JSON} | jq 'del(.image[] | select(. == "debian:stretch"))' | jq -c)
+          if [[ "${JSON}" != "{}" ]]; then
+            JSON=$(echo ${JSON} | jq 'del(.image[] | select(. == "debian:stretch"))' | jq -c)
+          fi
           echo "::set-output name=package_test_rules::${JSON}"
 
       - name: Print the loaded rules

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -196,8 +196,9 @@ on:
         default: ''
       deb_maintainer:
         description: "The name and email address of the Debian package maintainers, e.g. `The NLnet Labs RPKI Team <rpki@nlnetlabs.nl>`."
-        required: true
+        required: false
         type: string
+        default: ''
 
       cross_build_args:
         description: "Extra arguments to cargo build when cross-compiling, e.g. `--features static-openssl`."
@@ -392,6 +393,13 @@ jobs:
 
             if [[ "${{ inputs.docker_repo }}" == "" ]]; then
               echo "::error::Workflow input 'docker_repo' must be non-empty when 'docker_build_rules' are supplied."
+              exit 1
+            fi
+          fi
+
+          if [[ "${{ steps.select_inputs.outputs.package_build_rules }}" != '{}' ]]; then
+            if [[ "${{ inputs.deb_maintainer }}" == "" ]]; then
+              echo "::error::Workflow input 'deb_maintainer' must be non-empty when 'package_build_rules' are supplied."
               exit 1
             fi
           fi

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -254,10 +254,10 @@ jobs:
       all_repo_and_tag_pairs: ${{ steps.encode.outputs.all_repo_and_tag_pairs }}
       first_repo_and_tag_pair: ${{ steps.encode.outputs.first_repo_and_tag_pair }}
       lower_docker_org: ${{ steps.encode.outputs.lower_docker_org }}
-      cross_build_rules: ${{ steps.select_inputs.outputs.cross_build_rules }}
-      docker_build_rules: ${{ steps.select_inputs.outputs.docker_build_rules }}
-      package_build_rules: ${{ steps.select_inputs.outputs.package_build_rules }}
-      package_test_rules: ${{ steps.select_inputs.outputs.package_test_rules }}
+      cross_build_rules: ${{ steps.pre_process_rules.outputs.cross_build_rules }}
+      docker_build_rules: ${{ steps.pre_process_rules.outputs.docker_build_rules }}
+      package_build_rules: ${{ steps.pre_process_rules.outputs.package_build_rules }}
+      package_test_rules: ${{ steps.pre_process_rules.outputs.package_test_rules }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -298,8 +298,8 @@ jobs:
           from: yaml
           to: json
 
-      - name: Prefer loaded rules over inline rules
-        id: select_inputs
+      - name: Pre-process rule inputs
+        id: pre_process_rules
         run: |
           if [[ "${{ inputs.cross_build_rules_path }}" != "" ]]; then
             echo '::set-output name=cross_build_rules::${{ steps.transform_cross_build_rules_file.outputs.data }}'
@@ -338,7 +338,7 @@ jobs:
           echo "============================================================================="
           echo "Cross build rules:"
           echo "============================================================================="
-          JSON='${{ toJSON(fromJSON(steps.select_inputs.outputs.cross_build_rules)) }}'
+          JSON='${{ toJSON(fromJSON(steps.pre_process_rules.outputs.cross_build_rules)) }}'
           if [[ "${JSON}" != "[]" && "${JSON}" != '["no-cross"]' ]]; then
             echo ${JSON} | jq
           else
@@ -349,7 +349,7 @@ jobs:
           echo "============================================================================="
           echo "Docker build rules:"
           echo "============================================================================="
-          JSON='${{ toJSON(fromJSON(steps.select_inputs.outputs.docker_build_rules)) }}'
+          JSON='${{ toJSON(fromJSON(steps.pre_process_rules.outputs.docker_build_rules)) }}'
           if [[ "${JSON}" != "{}" ]]; then
             echo ${JSON} | jq
           else
@@ -360,7 +360,7 @@ jobs:
           echo "============================================================================="
           echo "Package build rules:"
           echo "============================================================================="
-          JSON='${{ toJSON(fromJSON(steps.select_inputs.outputs.package_build_rules)) }}'
+          JSON='${{ toJSON(fromJSON(steps.pre_process_rules.outputs.package_build_rules)) }}'
           if [[ "${JSON}" != "{}" ]]; then
             echo ${JSON} | jq
           else
@@ -371,7 +371,7 @@ jobs:
           echo "============================================================================="
           echo "Packages test rules:"
           echo "============================================================================="
-          JSON='${{ toJSON(fromJSON(steps.select_inputs.outputs.package_test_rules)) }}'
+          JSON='${{ toJSON(fromJSON(steps.pre_process_rules.outputs.package_test_rules)) }}'
           if [[ "${JSON}" != "{}" ]]; then
             echo ${JSON} | jq
           else
@@ -391,7 +391,7 @@ jobs:
             exit 1
           fi
 
-          if [[ "${{ steps.select_inputs.outputs.docker_build_rules }}" != '{}' ]]; then
+          if [[ "${{ steps.pre_process_rules.outputs.docker_build_rules }}" != '{}' ]]; then
             if [[ "${{ inputs.docker_org }}" == "" ]]; then
               echo "::error::Workflow input 'docker_org' must be non-empty when 'docker_build_rules' are supplied."
               exit 1
@@ -403,7 +403,7 @@ jobs:
             fi
           fi
 
-          if [[ "${{ steps.select_inputs.outputs.package_build_rules }}" != '{}' ]]; then
+          if [[ "${{ steps.pre_process_rules.outputs.package_build_rules }}" != '{}' ]]; then
             if [[ "${{ inputs.deb_maintainer }}" == "" ]]; then
               echo "::error::Workflow input 'deb_maintainer' must be non-empty when 'package_build_rules' are supplied."
               exit 1
@@ -411,7 +411,7 @@ jobs:
           fi
 
       - name: Verify Docker credentials
-        if: ${{ steps.select_inputs.outputs.docker_build_rules != '{}' }}
+        if: ${{ steps.pre_process_rules.outputs.docker_build_rules != '{}' }}
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKER_HUB_ID }}

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -248,7 +248,7 @@ jobs:
   # -------------------------------------------------------------------------------------------------------------------
   # Validate and pre-process inputs.
   prepare:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     outputs:
       all_repo_and_tag_pairs: ${{ steps.encode.outputs.all_repo_and_tag_pairs }}
       first_repo_and_tag_pair: ${{ steps.encode.outputs.first_repo_and_tag_pair }}
@@ -333,7 +333,7 @@ jobs:
           echo "============================================================================="
           JSON='${{ toJSON(fromJSON(steps.select_inputs.outputs.cross_build_rules)) }}'
           if [[ "${JSON}" != "[]" ]]; then
-            echo ${JSON}
+            echo ${JSON} | jq
           else
             echo None
           fi
@@ -344,7 +344,7 @@ jobs:
           echo "============================================================================="
           JSON='${{ toJSON(fromJSON(steps.select_inputs.outputs.docker_build_rules)) }}'
           if [[ "${JSON}" != "{}" ]]; then
-            echo ${JSON}
+            echo ${JSON} | jq
           else
             echo None
           fi
@@ -353,9 +353,9 @@ jobs:
           echo "============================================================================="
           echo "Package build rules:"
           echo "============================================================================="
-          JSON="${{ toJSON(fromJSON(steps.select_inputs.outputs.package_build_rules)) }}"
+          JSON='${{ toJSON(fromJSON(steps.select_inputs.outputs.package_build_rules)) }}'
           if [[ "${JSON}" != "{}" ]]; then
-            echo ${JSON}
+            echo ${JSON} | jq
           else
             echo None
           fi
@@ -366,7 +366,7 @@ jobs:
           echo "============================================================================="
           JSON='${{ toJSON(fromJSON(steps.select_inputs.outputs.package_test_rules)) }}'
           if [[ "${JSON}" != "{}" ]]; then
-            echo ${JSON}
+            echo ${JSON} | jq
           else
             echo None
           fi

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -1376,7 +1376,7 @@ jobs:
         run: |
           LOWER_DOCKER_ORG="${{ steps.decode.outputs.lower_docker_org }}"
 
-          ARCH_SHORT_NAMES=${{ join(fromJSON(needs.prepare.outputs.docker_build_rules).include.*.shortname, ' ') }}
+          ARCH_SHORT_NAMES="${{ join(fromJSON(needs.prepare.outputs.docker_build_rules).include.*.shortname, ' ') }}"
           REFERENCED_IMAGES=""
 
           # Imagine that we are invoked with two tags: v1.0.1 and latest

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -508,7 +508,7 @@ jobs:
     - name: Verify inputs
       id: verify
       run: |
-        if [[ "${{ matrix.target}" == "dummy" ]]; then
+        if [[ "${{ matrix.target }}" == "dummy" ]]; then
           echo "::set-output name=dummy::true"
         else
           echo "::set-output name=dummy::false"

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -333,7 +333,7 @@ jobs:
           echo "============================================================================="
           JSON='${{ toJSON(fromJSON(steps.select_inputs.outputs.cross_build_rules)) }}'
           if [[ "${JSON}" != "[]" ]]; then
-            echo ${JSON}
+            echo -e ${JSON}
           else
             echo None
           fi
@@ -344,7 +344,7 @@ jobs:
           echo "============================================================================="
           JSON='${{ toJSON(fromJSON(steps.select_inputs.outputs.docker_build_rules)) }}'
           if [[ "${JSON}" != "{}" ]]; then
-            echo ${JSON}
+            echo -e ${JSON}
           else
             echo None
           fi
@@ -355,7 +355,7 @@ jobs:
           echo "============================================================================="
           JSON='${{ toJSON(fromJSON(steps.select_inputs.outputs.package_build_rules)) }}'
           if [[ "${JSON}" != "{}" ]]; then
-            echo ${JSON}
+            echo -e ${JSON}
           else
             echo None
           fi
@@ -366,7 +366,7 @@ jobs:
           echo "============================================================================="
           JSON='${{ toJSON(fromJSON(steps.select_inputs.outputs.package_test_rules)) }}'
           if [[ "${JSON}" != "{}" ]]; then
-            echo ${JSON}
+            echo -e ${JSON}
           else
             echo None
           fi

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -333,7 +333,7 @@ jobs:
           echo "============================================================================="
           JSON='${{ toJSON(fromJSON(steps.select_inputs.outputs.cross_build_rules)) }}'
           if [[ "${JSON}" != "[]" ]]; then
-            echo -e ${JSON}
+            echo ${JSON}
           else
             echo None
           fi
@@ -344,7 +344,7 @@ jobs:
           echo "============================================================================="
           JSON='${{ toJSON(fromJSON(steps.select_inputs.outputs.docker_build_rules)) }}'
           if [[ "${JSON}" != "{}" ]]; then
-            echo -e ${JSON}
+            echo ${JSON}
           else
             echo None
           fi
@@ -353,9 +353,9 @@ jobs:
           echo "============================================================================="
           echo "Package build rules:"
           echo "============================================================================="
-          JSON='${{ toJSON(fromJSON(steps.select_inputs.outputs.package_build_rules)) }}'
+          JSON="${{ toJSON(fromJSON(steps.select_inputs.outputs.package_build_rules)) }}"
           if [[ "${JSON}" != "{}" ]]; then
-            echo -e ${JSON}
+            echo ${JSON}
           else
             echo None
           fi
@@ -366,7 +366,7 @@ jobs:
           echo "============================================================================="
           JSON='${{ toJSON(fromJSON(steps.select_inputs.outputs.package_test_rules)) }}'
           if [[ "${JSON}" != "{}" ]]; then
-            echo -e ${JSON}
+            echo ${JSON}
           else
             echo None
           fi

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -1150,6 +1150,7 @@ jobs:
   # NOTE: If you extend the set of matrix includes in this job you must also extend the call to docker manifest create
   # in the docker-manifest job below.
   docker:
+    if: ${{ inputs.docker_org != '' && inputs.docker_repo != '' }}
     needs: [cross, prepare]
     runs-on: ubuntu-20.04
     strategy:

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -297,7 +297,7 @@ jobs:
           from: yaml
           to: json
 
-      - name: Prefer inline rules over loaded rules
+      - name: Prefer loaded rules over inline rules
         id: select_inputs
         run: |
           if [[ "${{ inputs.cross_build_rules_path }}" != "" ]]; then

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -365,7 +365,7 @@ jobs:
           fi
 
       - name: Verify Docker credentials
-        # TODO: if Docker enabled
+        if: ${{ inputs.docker_org != '' && inputs.docker_repo != '' }}
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKER_HUB_ID }}

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -369,7 +369,7 @@ jobs:
           JSON='${{ toJSON(fromJSON(steps.select_inputs.outputs.package_test_rules)) }}'
 
           # Exclude debian:stretch because the LXC image is no longer available
-          JSON=$(echo ${JSON} | jq -c '. + {exclude: { image: "debian:stretch" }}')
+          JSON=$(echo ${JSON} | jq | grep -Fv '"debian:stretch"' | jq -c)
 
           if [[ "${JSON}" != "{}" ]]; then
             echo ${JSON} | jq

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -367,11 +367,9 @@ jobs:
           echo "============================================================================="
 
           JSON='${{ toJSON(fromJSON(steps.select_inputs.outputs.package_test_rules)) }}'
-
-          # Exclude debian:stretch because the LXC image is no longer available
-          JSON=$(echo ${JSON} | jq 'del(.image[] | select(. == "debian:stretch"))' | jq -c)
-
           if [[ "${JSON}" != "{}" ]]; then
+            # Exclude debian:stretch because the LXC image is no longer available
+            JSON=$(echo ${JSON} | jq 'del(.image[] | select(. == "debian:stretch"))' | jq -c)
             echo ${JSON} | jq
           else
             echo None

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -166,11 +166,13 @@ on:
       #   - The Tag would be v0.1.2-arm64
       # Collectively I refer to the combination of <org>/<repo>:<tag> as the 'image' name,
       docker_org:
-        required: true
+        required: false
         type: string
+        default: ''
       docker_repo:
-        required: true
+        required: false
         type: string
+        default: false
       docker_build_rules:
         description: "A GitHub Actions matrix in JSON format with platform, shortname, crosstarget (required if mode is copy), mode (optional: build or copy) and cargo_args (optional) fields."
         required: false
@@ -587,7 +589,7 @@ jobs:
     # Allow CentOS 8 to continue working now that it is EOL
     # See: https://stackoverflow.com/a/70930049
     - name: CentOS 8 EOL workaround
-      if: matrix.image == 'centos:8'
+      if: ${{ matrix.image == 'centos:8' }}
       run: |
         sed -i -e 's|mirrorlist=|#mirrorlist=|g' -e 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-Linux-*
 
@@ -649,7 +651,7 @@ jobs:
 
     # Only install cargo-deb or cargo-generate-rpm if not already fetched from the cache.
     - name: Install Cargo Deb if needed
-      if: steps.cache-cargo-deb.outputs.cache-hit != 'true'
+      if: ${{ steps.cache-cargo-deb.outputs.cache-hit != 'true' }}
       run: |
         case ${OS_NAME} in
           debian|ubuntu)
@@ -668,7 +670,7 @@ jobs:
         esac
 
     - name: Install Cargo Generate RPM if needed
-      if: steps.cache-cargo-generate-rpm.outputs.cache-hit != 'true'
+      if: ${{ steps.cache-cargo-generate-rpm.outputs.cache-hit != 'true' }}
       run: |
         case ${OS_NAME} in
           centos)
@@ -1208,12 +1210,14 @@ jobs:
           rm dockerbin/${{ matrix.platform }}/bins.tar
 
       - name: Log into Docker Hub
+        if: ${{ inputs.docker_org != '' && inputs.docker_repo != '' }}
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKER_HUB_ID }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
 
       - name: Generate architecture specific Docker image name
+        if: ${{ inputs.docker_org != '' && inputs.docker_repo != '' }}
         id: gen
         run: |
           # Use the [0]the tag, i.e. `<repo>:unstable`, `<repo>:test` or `<repo>:v0.1.2`.
@@ -1260,7 +1264,7 @@ jobs:
           path: /tmp/docker-${{ matrix.shortname }}-img.tar
 
       - name: Publish image to Docker Hub
-        if: contains(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main'
+        if: ${{ contains(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' }}
         uses: docker/build-push-action@v3
         with:
           context: .
@@ -1280,7 +1284,7 @@ jobs:
   # Logs in to Docker Hub using secrets configured in this GitHub repository.
   docker-manifest:
     needs: [prepare, docker]
-    if: contains(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main'
+    if: ${{ inputs.docker_org != '' && inputs.docker_repo != '' && contains(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-20.04
     steps:
       - name: Log into Docker Hub

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -326,7 +326,7 @@ jobs:
 
       - name: Print the loaded rules
         # Disable default use of bash -x for easier to read output in the log
-        shell: sh
+        shell: bash
         run: |
           echo "============================================================================="
           echo "Cross build rules:"

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -499,7 +499,7 @@ jobs:
   #
   # See: https://github.com/rust-embedded/cross#docker-in-docker
   cross:
-    if: ${{ needs.prepare.outputs.cross_build_rules != '[]' }}
+    # if: ${{ needs.prepare.outputs.cross_build_rules != '[]' }}
     needs: prepare
     runs-on: ubuntu-20.04
     strategy:

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -499,7 +499,7 @@ jobs:
   #
   # See: https://github.com/rust-embedded/cross#docker-in-docker
   cross:
-    # if: ${{ needs.prepare.outputs.cross_build_rules != '[]' }}
+    if: ${{ needs.prepare.outputs.cross_build_rules != '[]' }}
     needs: prepare
     runs-on: ubuntu-20.04
     strategy:
@@ -541,6 +541,11 @@ jobs:
         name: tmp-cross-binaries-${{ matrix.target }}
         path: bins.tar
 
+  cross-bridge:
+    if: ${{ always() }}
+    needs: cross
+    runs-on: ubuntu-20.04
+
   # -------------------------------------------------------------------------------------------------------------------
   # Job: 'pkg'
   # -------------------------------------------------------------------------------------------------------------------
@@ -549,8 +554,8 @@ jobs:
   #   - https://github.com/mmstick/cargo-deb
   #   - https://github.com/cat-in-136/cargo-generate-rpm
   pkg:
-    # if: ${{ needs.prepare.outputs.package_build_rules != '{}' }}
-    needs: [cross, prepare]
+    if: ${{ needs.prepare.outputs.package_build_rules != '{}' }}
+    needs: [cross-bridge, prepare]
     runs-on: ubuntu-latest
     # Build on the platform we are targeting in order to avoid https://github.com/rust-lang/rust/issues/57497.
     # Specifying container causes all of the steps in this job to run inside a Docker container (which is why the
@@ -1194,7 +1199,7 @@ jobs:
   # in the docker-manifest job below.
   docker:
     if: ${{ needs.prepare.outputs.docker_build_rules != '{}' }}
-    needs: [cross, prepare]
+    needs: [cross-bridge, prepare]
     runs-on: ubuntu-20.04
     strategy:
       fail-fast: false

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -320,10 +320,14 @@ jobs:
           fi
 
           if [[ "${{ inputs.package_test_rules_path }}" != "" ]]; then
-            echo '::set-output name=package_test_rules::${{ steps.transform_package_test_rules_file.outputs.data }}'
+            JSON='${{ steps.transform_package_test_rules_file.outputs.data }}'
           else
-            echo '::set-output name=package_test_rules::${{ inputs.package_test_rules }}'
+            JSON='${{ inputs.package_test_rules }}'
           fi
+
+          # Exclude debian:stretch because the LXC image is no longer available
+          JSON=$(echo ${JSON} | jq 'del(.image[] | select(. == "debian:stretch"))' | jq -c)
+          echo '::set-output name=package_test_rules::${JSON}'
 
       - name: Print the loaded rules
         # Disable default use of bash -x for easier to read output in the log
@@ -368,8 +372,6 @@ jobs:
 
           JSON='${{ toJSON(fromJSON(steps.select_inputs.outputs.package_test_rules)) }}'
           if [[ "${JSON}" != "{}" ]]; then
-            # Exclude debian:stretch because the LXC image is no longer available
-            JSON=$(echo ${JSON} | jq 'del(.image[] | select(. == "debian:stretch"))' | jq -c)
             echo ${JSON} | jq
           else
             echo None

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -380,12 +380,24 @@ jobs:
           fi
 
           if [[ ! -f ${{ inputs.rpm_scriptlets_path }} ]]; then
-            echo "::error::Workflow input '${{ inputs.rpm_scriptlets_path }}' must refer to a file in the Git checkout"
+            echo "::error::Workflow input 'rpm_scriptlets_path' ('${{ inputs.rpm_scriptlets_path }}') must refer to a file in the Git checkout"
             exit 1
           fi
 
+          if [[ "${{ steps.select_inputs.outputs.docker_build_rules }}" != '{}' ]]; then
+            if [[ "${{ inputs.docker_org }}" == "" ]]; then
+              echo "::error::Workflow input 'docker_org' must be non-empty when 'docker_build_rules' are supplied."
+              exit 1
+            fi
+
+            if [[ "${{ inputs.docker_repo }}" == "" ]]; then
+              echo "::error::Workflow input 'docker_repo' must be non-empty when 'docker_build_rules' are supplied."
+              exit 1
+            fi
+          fi
+
       - name: Verify Docker credentials
-        if: ${{ inputs.docker_org != '' && inputs.docker_repo != '' }}
+        if: ${{ steps.select_inputs.outputs.docker_build_rules != '{}' }}
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKER_HUB_ID }}
@@ -1173,7 +1185,7 @@ jobs:
   # NOTE: If you extend the set of matrix includes in this job you must also extend the call to docker manifest create
   # in the docker-manifest job below.
   docker:
-    if: ${{ inputs.docker_org != '' && inputs.docker_repo != '' && needs.prepare.outputs.docker_build_rules != '{}' }}
+    if: ${{ needs.prepare.outputs.docker_build_rules != '{}' }}
     needs: [cross, prepare]
     runs-on: ubuntu-20.04
     strategy:
@@ -1234,14 +1246,12 @@ jobs:
           rm dockerbin/${{ matrix.platform }}/bins.tar
 
       - name: Log into Docker Hub
-        if: ${{ inputs.docker_org != '' && inputs.docker_repo != '' }}
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKER_HUB_ID }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
 
       - name: Generate architecture specific Docker image name
-        if: ${{ inputs.docker_org != '' && inputs.docker_repo != '' }}
         id: gen
         run: |
           # Use the [0]the tag, i.e. `<repo>:unstable`, `<repo>:test` or `<repo>:v0.1.2`.
@@ -1308,7 +1318,7 @@ jobs:
   # Logs in to Docker Hub using secrets configured in this GitHub repository.
   docker-manifest:
     needs: [prepare, docker]
-    if: ${{ inputs.docker_org != '' && inputs.docker_repo != '' && contains(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' && needs.prepare.outputs.docker_build_rules != '{}' }}
+    if: ${{ contains(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' && needs.prepare.outputs.docker_build_rules != '{}' }}
     runs-on: ubuntu-20.04
     steps:
       - name: Log into Docker Hub

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -369,7 +369,7 @@ jobs:
           JSON='${{ toJSON(fromJSON(steps.select_inputs.outputs.package_test_rules)) }}'
 
           # Exclude debian:stretch because the LXC image is no longer available
-          JSON=$(echo ${JSON} | jq | grep -Fv '"debian:stretch"' | jq -c)
+          JSON=$(echo ${JSON} | jq 'del(.image[] | select(. == "debian:stretch"))' | jq -c)
 
           if [[ "${JSON}" != "{}" ]]; then
             echo ${JSON} | jq

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -133,7 +133,7 @@ on:
         description: "A JSON array of cross-compilation targets, e.g. [ 'arm-unknown-linux-musleabihf', 'armv7-unknown-linux-musleabihf' ]"
         required: false
         type: string
-        default: ''
+        default: '[]'
       cross_build_rules_path:
         description: "A relative path within the repository clone to a file containing a `cross_rules` array in YAML format. Each item in the array must be one of: https://github.com/cross-rs/cross#supported-targets"
         required: false
@@ -143,7 +143,7 @@ on:
         description: "A GitHub Actions matrix in JSON format with pkg (your app name), image (Docker image <os>:<rel>), target (x86_64, or a Rust target triple), extra_build_args (optional), os (optional) fields and (optional) include list. See also: https://doc.rust-lang.org/nightly/rustc/platform-support.html"
         required: false
         type: string
-        default: ''
+        default: '{}'
       package_build_rules_path:
         description: "A relative path within the repository clone to a file containing a `package_build_rules` matrix in YAML format."
         required: false
@@ -153,7 +153,7 @@ on:
         description: "A GitHub Actions matrix in JSON format with pkg (from package_build_rules), LXC image (<dist>:<rel>), target (from package_build_rules) and mode (fresh-install or upgrade-from-published). See also: https://uk.lxd.images.canonical.com/"
         required: false
         type: string
-        default: ''
+        default: '{}'
       package_test_rules_path:
         description: "A relative path within the repository clone to a file containing a `package_test_rules` matrix in YAML format."
         required: false
@@ -331,8 +331,9 @@ jobs:
           echo "============================================================================="
           echo "Cross build rules:"
           echo "============================================================================="
-          if [[ "${{ steps.select_inputs.outputs.cross_build_rules }}" != "" ]]; then
-            echo '${{ toJSON(fromJSON(steps.select_inputs.outputs.cross_build_rules)) }}'
+          JSON='${{ toJSON(fromJSON(steps.select_inputs.outputs.cross_build_rules)) }}'
+          if [[ "${JSON}" != "[]" ]]; then
+            echo ${JSON}
           else
             echo None
           fi
@@ -341,8 +342,9 @@ jobs:
           echo "============================================================================="
           echo "Docker build rules:"
           echo "============================================================================="
-          if [[ "${{ steps.select_inputs.outputs.docker_build_rules }}" != "" ]]; then
-            echo '${{ toJSON(fromJSON(steps.select_inputs.outputs.docker_build_rules)) }}'
+          JSON='${{ toJSON(fromJSON(steps.select_inputs.outputs.docker_build_rules)) }}'
+          if [[ "${JSON}" != "{}" ]]; then
+            echo ${JSON}
           else
             echo None
           fi
@@ -351,8 +353,9 @@ jobs:
           echo "============================================================================="
           echo "Package build rules:"
           echo "============================================================================="
-          if [[ "${{ steps.select_inputs.outputs.package_build_rules }}" != "" ]]; then
-            echo '${{ toJSON(fromJSON(steps.select_inputs.outputs.package_build_rules)) }}'
+          JSON='${{ toJSON(fromJSON(steps.select_inputs.outputs.package_build_rules)) }}'
+          if [[ "${JSON}" != "{}" ]]; then
+            echo ${JSON}
           else
             echo None
           fi
@@ -361,8 +364,9 @@ jobs:
           echo "============================================================================="
           echo "Packages test rules:"
           echo "============================================================================="
-          if [[ "${{ steps.select_inputs.outputs.package_test_rules }}" != "" ]]; then
-            echo '${{ toJSON(fromJSON(steps.select_inputs.outputs.package_test_rules)) }}'
+          JSON='${{ toJSON(fromJSON(steps.select_inputs.outputs.package_test_rules)) }}'
+          if [[ "${JSON}" != "{}" ]]; then
+            echo ${JSON}
           else
             echo None
           fi
@@ -475,6 +479,7 @@ jobs:
   #
   # See: https://github.com/rust-embedded/cross#docker-in-docker
   cross:
+    if: ${{ needs.prepare.outputs.cross_build_rules != '[]' }}
     needs: prepare
     runs-on: ubuntu-20.04
     strategy:
@@ -524,6 +529,7 @@ jobs:
   #   - https://github.com/mmstick/cargo-deb
   #   - https://github.com/cat-in-136/cargo-generate-rpm
   pkg:
+    if: ${{ needs.prepare.outputs.package_build_rules != '{}' }}
     needs: [cross, prepare]
     runs-on: ubuntu-latest
     # Build on the platform we are targeting in order to avoid https://github.com/rust-lang/rust/issues/57497.
@@ -936,6 +942,7 @@ jobs:
   # actual deployment targets, nor do GH runners support all targets that we want to test. Don't test in Docker
   # containers as they do not support systemd.
   pkg-test:
+    if: ${{ needs.prepare.outputs.package_test_rules != '{}' }}
     needs: [pkg, prepare]
     runs-on: ubuntu-20.04
     strategy:
@@ -1166,7 +1173,7 @@ jobs:
   # NOTE: If you extend the set of matrix includes in this job you must also extend the call to docker manifest create
   # in the docker-manifest job below.
   docker:
-    if: ${{ inputs.docker_org != '' && inputs.docker_repo != '' }}
+    if: ${{ inputs.docker_org != '' && inputs.docker_repo != '' && needs.prepare.outputs.docker_build_rules != '{}' }}
     needs: [cross, prepare]
     runs-on: ubuntu-20.04
     strategy:
@@ -1301,7 +1308,7 @@ jobs:
   # Logs in to Docker Hub using secrets configured in this GitHub repository.
   docker-manifest:
     needs: [prepare, docker]
-    if: ${{ inputs.docker_org != '' && inputs.docker_repo != '' && contains(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' }}
+    if: ${{ inputs.docker_org != '' && inputs.docker_repo != '' && contains(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' && needs.prepare.outputs.docker_build_rules != '{}' }}
     runs-on: ubuntu-20.04
     steps:
       - name: Log into Docker Hub


### PR DESCRIPTION
This PR fixes issues that were preventing the krill-sync project moving to the reusable packaging workflow. The changes made to krill-sync (in PR NLnetLabs/krill-sync#66) are nothing special, but they use a feature of the reusable packaging workflow that was not yet fully tested, or rather the lack of features as krill-sync does not build packages:

- For non-x86_64 platforms and thus does not need to provide cross-compilation build rules.
- To Docker Hub and thus does not need to provide Docker login authentication secrets or build rules.

The reusable packaging workflow **should** work if only some of its abilities are used, but this was not yet the case. This PR resolves these issues.

This PR is backward compatible, it only fixes functionality that should already have worked and while it changes default input values it does not change the meaning of those default input values and so does not affect existing users of the reusable packaging workflow.

The noteworthy changes in this PR are:
- Enable use of the packaging workflow with none, some or all of the various build rules provided. The test `pkg.yml` workflow in the NLnetLabs/.github-testing project has been extended to test various permutations of provided and missing build rules. For a successful run of that workflow against the branch for PR NLnetLabs/.github-testing#3 see: https://github.com/NLnetLabs/.github-testing/actions/runs/3049257474
- Default values for rules inputs have been changed in value, but not meaning, to empty JSON values, except for the `cross_build_rules` which default to a new special value `["no-cross"]`. These changes made it easier to improve the diagnostic printing of found rules (now pretty printed - via `jq` which is pre-installed in the GH runner Ubuntu 22.04 image used) rather than smashed on one line and to make cross-compilation an optional step (it still executes but does nothing as skipping it entirely proved difficult to implement).
- The `deb_maintainer` input is now optional (as it should have been) and checked to be non-empty if `packages_to_build` rules are provided.
- The `docker_org` and `docker_repo` inputs are now optional (as they should have been) and default to empty strings. IFF `docker_build_rules` are supplied then Docker secrets are verified by a login check (which was previously always done instead of only for Docker builds), and `docker_org` and `docker_repo` are checked to be non-empty.
- The GH runner host for the `prepare` job has been bumped from Ubuntu 20.04 to Ubuntu 22.04. This won't affect anything as the job does very little, but there was also no reason to use an older version and I verified that [the Ubuntu 22.04 image has `jq` pre-installed](https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2204-Readme.md#tools) (maybe the older version does as well but I didn't check that).
- Attempts to use the `debian:stretch` image in the `package_test_rules` matrix will **now cause a warning** to be shown in the workflow report and it will be removed from the matrix. This is because the LXC image for Debian Stretch no longer exists on https://images.linuxcontainers.org/ and so the `pkg-test` job fails if it attempts to run tests for that O/S version. Handling this in the reusable workflow prevents avoidable failures in consumer workflows.