### PR TITLE
Work around dot slash data tar problem with unattended upgrades

### DIFF
--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -880,9 +880,9 @@ jobs:
             # Patch the generated DEB to have ./ paths compatible with `unattended-upgrade`:
             pushd target/debian
             DEB_FILE_NAME=$(ls -1 *.deb | head -n 1)
-            tar tf ${DEB_FILE_NAME}
             DATA_ARCHIVE=$(ar t ${DEB_FILE_NAME} | grep -E '^data\.tar')
             ar x ${DEB_FILE_NAME} ${DATA_ARCHIVE}
+            tar tf ${DATA_ARCHIVE}
             EXTRA_TAR_ARGS=
             if [[ "${DATA_ARCHIVE}" == *.xz ]]; then
               # Install XZ support that will be needed by TAR
@@ -894,8 +894,8 @@ jobs:
             pushd tar-hack
             tar c${EXTRA_TAR_ARGS}f ../${DATA_ARCHIVE} ./*
             popd
+            tar tf ${DATA_ARCHIVE}
             ar r ${DEB_FILE_NAME} ${DATA_ARCHIVE}
-            tar tf ${DEB_FILE_NAME}
 
             ls -la target/debian/
             ;;

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -896,6 +896,7 @@ jobs:
             popd
             tar tf ${DATA_ARCHIVE}
             ar r ${DEB_FILE_NAME} ${DATA_ARCHIVE}
+            popd
 
             ls -la target/debian/
             ;;

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -679,7 +679,7 @@ jobs:
       run: |
         case ${OS_NAME} in
           debian|ubuntu)
-            apt-get install -y build-essential jq lintian pkg-config ${{ inputs.deb_extra_build_packages }}
+            apt-get install -y binutils build-essential jq lintian pkg-config ${{ inputs.deb_extra_build_packages }}
             ;;
           centos)
             yum install epel-release -y
@@ -875,6 +875,27 @@ jobs:
             rm -f target/debian/*.deb
 
             cargo deb --deb-version ${DEB_VER} ${OPT_VARIANT_ARG} -v ${EXTRA_CARGO_DEB_ARGS} -- --locked ${EXTRA_BUILD_ARGS}
+
+            # https://github.com/NLnetLabs/routinator/issues/783
+            # Patch the generated DEB to have ./ paths compatible with `unattended-upgrade`:
+            pushd target/debian
+            DEB_FILE_NAME=$(ls -1 *.deb | head -n 1)
+            tar tf ${DEB_FILE_NAME}
+            DATA_ARCHIVE=$(ar t ${DEB_FILE_NAME} | grep -E '^data\.tar')
+            ar x ${DEB_FILE_NAME} ${DATA_ARCHIVE}
+            EXTRA_TAR_ARGS=
+            if [[ "${DATA_ARCHIVE}" == *.xz ]]; then
+              # Install XZ support that will be needed by TAR
+              apt install -y xz-utils
+              EXTRA_TAR_ARGS=J
+            fi
+            mkdir tar-hack
+            tar -C tar-hack -xf ${DATA_ARCHIVE}
+            pushd tar-hack
+            tar c${EXTRA_TAR_ARGS}f ../${DATA_ARCHIVE} ./*
+            popd
+            ar r ${DEB_FILE_NAME} ${DATA_ARCHIVE}
+            tar tf ${DEB_FILE_NAME}
 
             ls -la target/debian/
             ;;


### PR DESCRIPTION
This PR applies the work around proposed in https://github.com/NLnetLabs/routinator/issues/783.

Prior to the work around being applied the DEB package is built as before and we can [clearly see](https://github.com/NLnetLabs/.github-testing/actions/runs/3052945132/jobs/4923082743#step:16:275) the lack of a leading `./` in the paths inside that data tarball, reproduced here for ease:

```
+ tar tf data.tar.xz
usr/
usr/share/
usr/share/doc/
usr/share/doc/mytest/
usr/share/doc/mytest/copyright
usr/share/doc/mytest/changelog.Debian.gz
usr/bin/
usr/bin/hello_cargo
```

Next the work around is applied and the data tarball is modified and replaced inside the DEB archive. The listing of the modified tar archive prior to (r)eplacing it with the `ar r` command in the DEB archive [clearly shows](https://github.com/NLnetLabs/.github-testing/actions/runs/3052945132/jobs/4923082743#step:16:303) the paths are now `./` prefixed, reproduced here for ease:

```
+ tar tf data.tar.xz
./usr/
./usr/bin/
./usr/bin/hello_cargo
+ ar r mytest_0.1.0-1jammy_amd64.deb data.tar.xz
./usr/share/
./usr/share/doc/
./usr/share/doc/mytest/
./usr/share/doc/mytest/copyright
./usr/share/doc/mytest/changelog.Debian.gz
```

_(ignore the interwoven `+ar r` command, that's just an artifact of the way GitHub Actions captures command output)_

If we then download the produced workflow artifact `mytest_0.1.0-1jammy_amd64.deb` and inspect it in a Debian 11 Docker container we see the `./` paths are indeed preserved:

```
root@1e412154ecaf:/# dpkg-deb --fsys-tarfile /tmp/mytest_0.1.0-1jammy_amd64.deb | tar tf -
./usr/
./usr/bin/
./usr/bin/hello_cargo
./usr/share/
./usr/share/doc/
./usr/share/doc/mytest/
./usr/share/doc/mytest/copyright
./usr/share/doc/mytest/changelog.Debian.gz
```

The intent of this PR was to prefix data archive paths with `./` and it appears to do exactly that.