### PR TITLE
Verify that upgrades dont revert conffile modifications

### DIFF
--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -1136,7 +1136,7 @@ jobs:
             CONFIFILE_LIST_FILE="/var/lib/dpkg/info/${{ matrix.pkg }}.conffiles"
 
             # append a line break to the conffile
-            for F in $(sg lxd -c "lxc exec testcon -- cat ${CONFIFILE_LIST_FILE}); do
+            for F in $(sg lxd -c "lxc exec testcon -- cat ${CONFIFILE_LIST_FILE}"); do
               sg lxd -c "lxc exec testcon -- sh -c \"echo >> $F\""
             done
 

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -1118,6 +1118,7 @@ jobs:
         esac
 
     - name: Install previously published ${{ matrix.pkg }} package
+      id: instprev
       if: ${{ matrix.mode == 'upgrade-from-published' }}
       run: |
         case ${OS_NAME} in
@@ -1128,6 +1129,19 @@ jobs:
             sg lxd -c "lxc exec testcon -- apt-key add ./aptkey.asc"
             sg lxd -c "lxc exec testcon -- apt update"
             sg lxd -c "lxc exec testcon -- apt install -y ${{ matrix.pkg }}"
+
+            # determine the conffiles, append a harmless line break to each one (so that they are modified) then save
+            # the md5sums of the modified files for comparison after upgrade to ensure our edits are not overwritten
+            SAVED_MD5SUMS="/tmp/${{ matrix.pkg }}-conffiles.md5"
+            CONFIFILE_LIST_FILE="/var/lib/dpkg/info/${{ matrix.pkg }}.conffiles"
+
+            # append a line break to the conffile
+            for F in $(sg lxd -c "lxc exec testcon -- cat ${CONFIFILE_LIST_FILE}); do
+              sg lxd -c "lxc exec testcon -- sh -c \"echo >> $F\""
+            done
+
+            # save the md5 checksums for later comparison
+            sg lxd -c "lxc exec testcon -- sh -c \"cat ${CONFIFILE_LIST_FILE} | xargs md5sum > ${SAVED_MD5SUMS}\""
             ;;
           centos)
             echo '[nlnetlabs]' >$HOME/nlnetlabs.repo
@@ -1169,6 +1183,18 @@ jobs:
             ;;
           centos)
             sg lxd -c "lxc exec testcon -- yum install -y /tmp/${PKG_FILE}"
+            ;;
+        esac
+
+    - name: Verify that conffiles have not been altered by the upgrade
+      if: ${{ matrix.mode == 'upgrade-from-published' }}
+      run: |
+        case ${OS_NAME} in
+          debian|ubuntu)
+            SAVED_MD5SUMS="/tmp/${{ matrix.pkg }}-conffiles.md5"
+            md5sum -c ${SAVED_MD5SUMS}
+            ;;
+          centos)
             ;;
         esac
 

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -1193,7 +1193,7 @@ jobs:
         case ${OS_NAME} in
           debian|ubuntu)
             SAVED_MD5SUMS="/tmp/${{ matrix.pkg }}-conffiles.md5"
-            md5sum -c ${SAVED_MD5SUMS}
+            sg lxd -c "lxc exec testcon -- md5sum -c ${SAVED_MD5SUMS}"
             ;;
           centos)
             ;;

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -1141,7 +1141,7 @@ jobs:
             done
 
             # save the md5 checksums for later comparison
-            sg lxd -c "lxc exec testcon -- sh -c \"xargs ${CONFIFILE_LIST_FILE} md5sum > ${SAVED_MD5SUMS}\""
+            sg lxd -c "lxc exec testcon -- sh -c \"xargs -a ${CONFIFILE_LIST_FILE} md5sum > ${SAVED_MD5SUMS}\""
             sg lxd -c "lxc exec testcon -- cat ${SAVED_MD5SUMS}"
             ;;
           centos)

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -1141,7 +1141,8 @@ jobs:
             done
 
             # save the md5 checksums for later comparison
-            sg lxd -c "lxc exec testcon -- sh -c \"cat ${CONFIFILE_LIST_FILE} | xargs md5sum > ${SAVED_MD5SUMS}\""
+            sg lxd -c "lxc exec testcon -- sh -c \"xargs ${CONFIFILE_LIST_FILE} md5sum > ${SAVED_MD5SUMS}\""
+            sg lxd -c "lxc exec testcon -- cat ${SAVED_MD5SUMS}"
             ;;
           centos)
             echo '[nlnetlabs]' >$HOME/nlnetlabs.repo


### PR DESCRIPTION
This PR modifies the DEB packaging process to ensure that files marked as Debian `conffiles` are not overwritten when upgrading if the `conffiles` were locally modified.

A successful test run of this workflow using Routinator as an example can be seen here: https://github.com/NLnetLabs/routinator/actions/runs/3052918081. A run with a real product made it easier to verify after a package upgrade that files were not changed, because Routinator already has released package versions which can be installed and upgraded from to a new test version, we don't have to package both a mock old and mock new version.

[Here](https://github.com/NLnetLabs/routinator/actions/runs/3052918081/jobs/4924715866#step:13:135) we can see the the `conffiles` being harmlessly modified and then their MD5 checksums being saved.

[Here](https://github.com/NLnetLabs/routinator/actions/runs/3052918081/jobs/4924715866#step:17:21) we see post-upgrade that the MD5 sums have been checked and are correctly unchanged.