### PR TITLE
Release v1.0.4

### DIFF
--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -1434,7 +1434,7 @@ jobs:
           for REPO_AND_TAG in ${{ steps.decode.outputs.repo_and_tag_pairs }}; do
             if [[ "${REFERENCED_IMAGES}" == "" ]]; then
               for ARCH_SHORT_NAME in ${ARCH_SHORT_NAMES}; do
-                REFERENCED_IMAGES="${LOWER_DOCKER_ORG}/${REPO_AND_TAG}-${ARCH_SHORT_NAME} "
+                REFERENCED_IMAGES="${REFERENCED_IMAGES} ${LOWER_DOCKER_ORG}/${REPO_AND_TAG}-${ARCH_SHORT_NAME} "
               done
             fi
 


### PR DESCRIPTION
This PR is the start of the release process for v1.0.4 of the reusable packaging workflow which includes the following changes:
- #8
  - Works around Routinator issue NLnetLabs/routinator#783
- #9
  - No issue seen but as we depend on behavour in [`cargo-deb`](https://crates.io/crates/cargo-deb) to implement this it's worth verifying that it behaves as expected.
- Fixes Docker manifest publication for the case where there are multiple referenced images, as since v1.0.0 only the first was being referenced. This issue was caught now because the test suite was updated to create multiple different architecture images which caused this issue to show up.