### PR TITLE
Error when no conffiles exist when DEB packaging

### DIFF
--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -1164,8 +1164,9 @@ jobs:
             done
 
             # save the md5 checksums for later comparison
-            sg lxd -c "lxc exec testcon -- sh -c \"xargs -a ${CONFIFILE_LIST_FILE} md5sum > ${SAVED_MD5SUMS}\""
-            sg lxd -c "lxc exec testcon -- cat ${SAVED_MD5SUMS}"
+            if sg lxd -c "lxc exec testcon -- sh -c \"xargs -a ${CONFIFILE_LIST_FILE} md5sum > ${SAVED_MD5SUMS}\""; then
+              sg lxd -c "lxc exec testcon -- cat ${SAVED_MD5SUMS}"
+            fi
             ;;
           centos)
             echo '[nlnetlabs]' >$HOME/nlnetlabs.repo
@@ -1216,7 +1217,7 @@ jobs:
         case ${OS_NAME} in
           debian|ubuntu)
             SAVED_MD5SUMS="/tmp/${{ matrix.pkg }}-conffiles.md5"
-            sg lxd -c "lxc exec testcon -- md5sum -c ${SAVED_MD5SUMS}"
+            sg lxd -c "lxc exec testcon -- sh -c '[ ! -f ${SAVED_MD5SUMS} ] || md5sum -c ${SAVED_MD5SUMS}'"
             ;;
           centos)
             ;;

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -1166,6 +1166,9 @@ jobs:
             # save the md5 checksums for later comparison
             if sg lxd -c "lxc exec testcon -- sh -c \"xargs -a ${CONFIFILE_LIST_FILE} md5sum > ${SAVED_MD5SUMS}\""; then
               sg lxd -c "lxc exec testcon -- cat ${SAVED_MD5SUMS}"
+            else
+              echo "Conffile change preservation checking will be skipped because no conffiles were detected."
+              sg lxd -c "lxc exec testcon -- rm -f ${SAVED_MD5SUMS}"
             fi
             ;;
           centos)


### PR DESCRIPTION
The recently added checks for conffiles remaining unmodified on upgrade fail if the project has no conffiles at all. This PR fixes that. The issue was discovered in the Krill project, not by the tests in NLnetLabs/.github-testing. The latter cannot currently test for this issue as it requires an existing published package to test upgrading against. Instead I have successfully tested this branch against Krill here: https://github.com/NLnetLabs/krill/actions/runs/3065724899/jobs/4951816132

- [x] 1. Create a branch in the RELEASE repo, let's call this the RELEASE branch. _**This PR branch.**_
- [x] 2. Create a PR in the RELEASE repo for the RELEASE branch. _**This PR**_
- [x] 3. Create a matching branch in the TEST repo, let's call this the TEST branch. _**`error-when-no-conffiles` in NLnetLabs/.github-testing**_
- [x] 4. Make the desired changes to the RELEASE branch.
- [x] 5. In the TEST branch modify `.github/workflows/pkg.yml` so that instead of referring to `pkg-rust.yml@v1` it refers to `pkg-rust.yml@<Git ref of HEAD commit on the TEST branch>` or `pkg-rust.yml@<test branch name>`.
- [x] 6. Create a PR in the `.gihub-testing` repository from the TEST branch to `main`, let's call this the TEST PR. _**NLnetLabs/.github-testing#6**_
- [x] 7. Repeat steps 3 and 4 until the the `Packaging` workflow run in the TEST PR passes and behaves as desired.
- [x] 8. Merge the TEST PR to the `main` branch.
- [x] 9. Verify that the automatically invoked run of the `Packaging` workflow in the TEST repo against the `main` branch passes and behaves as desired. If not, repeat steps 2-7 until the new TEST PR passes and behaves as desired.
- [x] 10. Create a release tag in the TEST repo with the same release tag as will be used in the RELEASE repo, e.g. v1.2.3. _**Note:** Remember to respect semantic versioning, i.e. if the changes being made are not backward compatible you will need to bump the MAJOR version (in MAJOR.MINOR.PATCH) **and** any workflows that invoke the reusable workflow will need to be **manually edited** to refer to the new MAJOR version._
- [x] 11. Verify that the automatically invoked run of the `Packaging` workflow in the TEST repo passes against the newly created release tag passes and behaves as desired. If not, delete the release tag **in the TEST repo** and repeat steps 2-9 until the new TEST PR passes and behaves as desired.
- [ ] 12. Merge the RELEASE PR to the `main` branch.
- [ ] 13. Create the new release vX.Y.Z tag in the RELEASE repo.
- [ ] 14. Update the v1 tag in the RELEASE repo to point to the new vX.Y.Z tag.
- [ ] 15. Edit `.github/workflows/pkg.yml` in the `main` branch of the TEST repo to refer again to `@v1`.
- [ ] 16. Verify that the `Packaging` action in the TEST repo against the `main` branch passes and works as desired.
- [ ] 17. (optional) If the MAJOR version was changed, update affected repositories that use the reusable workflow to use the new MAJOR version, including adjusting to any breaking changes introduced by the MAJOR version change.