### PR TITLE
14 nodejs 12 actions are deprecated

### DIFF
--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -528,7 +528,7 @@ jobs:
 
     - name: Checkout repository
       if: ${{ steps.verify.outputs.no-cross == 'false' }}
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Cache cargo cross
       if: ${{ steps.verify.outputs.no-cross == 'false' }}
@@ -588,7 +588,7 @@ jobs:
       CARGO_GENERATE_RPM_VER: 0.8.0
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Verify inputs
       run: |
@@ -1018,7 +1018,7 @@ jobs:
     steps:
     # Fetch the test scripts that we will run
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Verify inputs
       run: |
@@ -1279,7 +1279,7 @@ jobs:
       matrix: ${{ fromJSON(needs.prepare.outputs.docker_build_rules) }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Verify inputs
         run: |

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -1332,7 +1332,7 @@ jobs:
           rm dockerbin/${{ matrix.platform }}/bins.tar
 
       - name: Log into Docker Hub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKER_HUB_ID }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
@@ -1408,7 +1408,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Log into Docker Hub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKER_HUB_ID }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}


### PR DESCRIPTION
- [x] 1. Create a branch in the RELEASE repo, let's call this the RELEASE branch. _**This PR branch**_
- [x] 2. Create a PR in the RELEASE repo for the RELEASE branch. _**This PR**_
- [x] 3. Create a matching branch in the TEST repo, let's call this the TEST branch.
- [x] 4. Make the desired changes to the RELEASE branch.
- [x] 5. In the TEST branch modify `.github/workflows/pkg.yml` so that instead of referring to `pkg-rust.yml@v1` it refers to `pkg-rust.yml@<Git ref of HEAD commit on the TEST branch>` or `pkg-rust.yml@<test branch name>`.
- [x] 6. Create a PR in the `.gihub-testing` repository from the TEST branch to `main`, let's call this the TEST PR.
- [x] 7. Repeat steps 3 and 4 until the the `Packaging` workflow run in the TEST PR passes and behaves as desired.
- [x] 8. Merge the TEST PR to the `main` branch.
- [x] 9. Verify that the automatically invoked run of the `Packaging` workflow in the TEST repo against the `main` branch passes and behaves as desired. If not, repeat steps 2-7 until the new TEST PR passes and behaves as desired.
- [x] 10. Create a release tag in the TEST repo with the same release tag as will be used in the RELEASE repo, e.g. v1.2.3. _**Note:** Remember to respect semantic versioning, i.e. if the changes being made are not backward compatible you will need to bump the MAJOR version (in MAJOR.MINOR.PATCH) **and** any workflows that invoke the reusable workflow will need to be **manually edited** to refer to the new MAJOR version._
- [x] 11. Verify that the automatically invoked run of the `Packaging` workflow in the TEST repo passes against the newly created release tag passes and behaves as desired. If not, delete the release tag **in the TEST repo** and repeat steps 2-9 until the new TEST PR passes and behaves as desired.
- [x] 12. Merge the RELEASE PR to the `main` branch.
- [ ] 13. Create the new release vX.Y.Z tag in the RELEASE repo.
- [ ] 14. Update the v1 tag in the RELEASE repo to point to the new vX.Y.Z tag.
- [ ] 15. Edit `.github/workflows/pkg.yml` in the `main` branch of the TEST repo to refer again to `@v1`.
- [ ] 16. Verify that the `Packaging` action in the TEST repo against the `main` branch passes and works as desired.
- [ ] 17. (optional) If the MAJOR version was changed, update affected repositories that use the reusable workflow to use the new MAJOR version, including adjusting to any breaking changes introduced by the MAJOR version change.