### PR TITLE
Release v1.0.8

### DIFF
--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -1207,7 +1207,8 @@ jobs:
       run: |
         case ${OS_NAME} in
           debian|ubuntu)
-            sg lxd -c "lxc exec testcon -- apt-get -y install /tmp/${PKG_FILE}"
+            # See https://github.com/NLnetLabs/.github/issues/17 regarding --force-confXXX
+            sg lxd -c "lxc exec testcon -- apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install /tmp/${PKG_FILE}"
             ;;
           centos)
             sg lxd -c "lxc exec testcon -- yum install -y /tmp/${PKG_FILE}"

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -1095,7 +1095,7 @@ jobs:
       run: |
         # security.nesting=true is needed to avoid error "Failed to set up mount namespacing: Permission denied" in a
         # Debian 10 container.
-        sg lxd -c "lxc launch ${LXC_IMAGE} -c security.nesting=true testcon"
+        sg lxd -c "lxc launch ${LXC_IMAGE} -c security.nesting=true -c environment.DEBIAN_FRONTEND=noninteractive testcon"
 
     # Run package update and install man and sudo support (missing in some LXC/LXD O/S images) but first wait for
     # cloud-init to finish otherwise the network isn't yet ready. Don't use cloud-init status --wait as that isn't


### PR DESCRIPTION
- [x] 1. Create a branch in the RELEASE repo, let's call this the RELEASE branch.
- [x] 2. Create a PR in the RELEASE repo for the RELEASE branch.
- [x] 3. Create a matching branch in the TEST repo, let's call this the TEST branch.
- [x] 4. Make the desired changes to the RELEASE branch.
- [x] 5. In the TEST branch modify `.github/workflows/pkg.yml` so that instead of referring to `pkg-rust.yml@v1` it refers to `pkg-rust.yml@<Git ref of HEAD commit on the TEST branch>` or `pkg-rust.yml@<test branch name>`.
- [x] 6. Create a PR in the `.gihub-testing` repository from the TEST branch to `main`, let's call this the TEST PR.
- [x] 7. Repeat steps 3 and 4 until the the `Packaging` workflow run in the TEST PR passes and behaves as desired.
- [x] 8. Merge the TEST PR to the `main` branch.
- [x] 9. Verify that the automatically invoked run of the `Packaging` workflow in the TEST repo against the `main` branch passes and behaves as desired. If not, repeat steps 2-7 until the new TEST PR passes and behaves as desired.
- [x] 10. Create a release tag in the TEST repo with the same release tag as will be used in the RELEASE repo, e.g. v1.2.3. _**Note:** Remember to respect semantic versioning, i.e. if the changes being made are not backward compatible you will need to bump the MAJOR version (in MAJOR.MINOR.PATCH) **and** any workflows that invoke the reusable workflow will need to be **manually edited** to refer to the new MAJOR version._
- [x] 11. Verify that the automatically invoked run of the `Packaging` workflow in the TEST repo passes against the newly created release tag passes and behaves as desired. If not, delete the release tag **in the TEST repo** and repeat steps 2-9 until the new TEST PR passes and behaves as desired.
- [ ] 12. Merge the RELEASE PR to the `main` branch.
- [ ] 13. Create the new release vX.Y.Z tag in the RELEASE repo.
- [ ] 14. Update the v1 tag in the RELEASE repo to point to the new vX.Y.Z tag.
- [ ] 15. Edit `.github/workflows/pkg.yml` in the `main` branch of the TEST repo to refer again to `@v1`.
- [ ] 16. Verify that the `Packaging` action in the TEST repo against the `main` branch passes and works as desired.
- [ ] 17. (optional) If the MAJOR version was changed, update affected repositories that use the reusable workflow to use the new MAJOR version, including adjusting to any breaking changes introduced by the MAJOR version change.
