### PR TITLE
Allow upgrade failure

### DIFF
--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -1321,7 +1321,7 @@ jobs:
 
     - name: Check whether upgrade failure is fatal
       if: ${{ steps.upgrade_package.outcome == 'failure' && !inputs.package_tests_ignore_upgrade_failure }}
-      uses: actions/github-script@v3
+      uses: actions/github-script@v6
       with:
         script: |
           core.setFailed("Package upgrade failed unexpectedly")

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -238,6 +238,11 @@ on:
         required: false
         type: string
         default: ''
+      package_tests_ignore_upgrade_failure:
+        description: "Whether to ignore package upgrade failure or not. If the previous release causes errors on upgrade, set this to true."
+        required: false
+        type: boolean
+        default: false
 
     secrets:
       DOCKER_HUB_ID:
@@ -1298,6 +1303,8 @@ jobs:
         sg lxd -c "lxc exec testcon -- /tmp/test.sh post-install"
 
     - name: Upgrade from the published ${{ matrix.pkg }} package to the newly built package
+      id: upgrade_package
+      continue-on-error: true
       if: ${{ matrix.mode == 'upgrade-from-published' }}
       run: |
         case ${OS_NAME} in
@@ -1311,6 +1318,13 @@ jobs:
             ! grep -qE '(err|warn|fail)' upgrade.log
             ;;
         esac
+
+    - name: Check whether upgrade failure is fatal
+      if: ${{ steps.upgrade_package.outcome == 'failure' && !inputs.package_tests_ignore_upgrade_failure }}
+      uses: actions/github-script@v3
+      with:
+        script: |
+          core.setFailed("Package upgrade failed unexpectedly")
 
     - name: Verify that conffiles have not been altered by the upgrade
       if: ${{ matrix.mode == 'upgrade-from-published' }}

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -1319,7 +1319,7 @@ jobs:
             ;;
         esac
 
-    - name: Check whether upgrade failure is fatal
+    - name: Require successful upgrade
       if: ${{ steps.upgrade_package.outcome == 'failure' && !inputs.package_tests_ignore_upgrade_failure }}
       uses: actions/github-script@v6
       with:


### PR DESCRIPTION
Routinator needs this as the published v0.11.3 RPM scriptlets fail on upgrade.