### PR TITLE
Add an output indicating if Docker publishing happened or not.

### DIFF
--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -245,6 +245,11 @@ on:
       DOCKER_HUB_TOKEN:
         required: false
 
+    outputs:
+      docker_published:
+        description: "Whether publishing of Docker images was done or not."
+        value: ${{ jobs.docker.outputs.published }}
+
 defaults:
   run:
     # see: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#using-a-specific-shell
@@ -1370,6 +1375,8 @@ jobs:
   # in the docker-manifest job below.
   docker:
     if: ${{ needs.prepare.outputs.docker_build_rules != '{}' }}
+    outputs:
+      published: ${{ steps.publish.conclusion == 'success' }}
     needs: [cross, prepare]
     runs-on: ubuntu-20.04
     strategy:
@@ -1493,6 +1500,7 @@ jobs:
           path: /tmp/docker-${{ matrix.shortname }}-img.tar
 
       - name: Publish image to Docker Hub
+        id: publish
         if: ${{ needs.prepare.outputs.has_docker_secrets && contains(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' }}
         uses: docker/build-push-action@v3
         with:


### PR DESCRIPTION
This is useful for pre-release testing of the packaging workflow as non-publication because the step was skipped won't be a workflow failure so the test workflows in NLnetLabs/.github-testing won't fail, but with this the test workflows can explicitly check for the expected publication state.