### PR TITLE
Automated cross-compilation target determination.

### DIFF
--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -318,9 +318,7 @@ jobs:
           if [ "${ALL_TARGETS}" == '[]' ]; then
             echo '{}' >> $GITHUB_OUTPUT
           else
-            echo '{ "target": ' >> $GITHUB_OUTPUT
-            echo ${ALL_TARGETS} | jq
-            echo '}' >> $GITHUB_OUTPUT
+            echo '{ "target": ' ${ALL_TARGETS} '}' | jq >> $GITHUB_OUTPUT
           fi
           echo 'END_OF_TARGETS' >> $GITHUB_OUTPUT
 

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -664,6 +664,8 @@ jobs:
     # Install Rust the hard way rather than using a GH Action because the action doesn't work inside a Docker container.
     - name: Install Rust
       run: |
+        trap 'kill -term %1 SIGINT
+
         case ${OS_NAME} in
           debian|ubuntu)
             apt-get update
@@ -679,6 +681,8 @@ jobs:
 
     - name: Install compilation and other dependencies
       run: |
+        trap 'kill -term %1 SIGINT
+
         case ${OS_NAME} in
           debian|ubuntu)
             apt-get install -y binutils build-essential jq lintian pkg-config ${{ inputs.deb_extra_build_packages }}
@@ -1192,6 +1196,8 @@ jobs:
     - name: Prepare container
       shell: bash
       run: |
+        trap 'kill -term %1 SIGINT
+
         echo "Waiting for cloud-init.."
         while ! sudo lxc exec testcon -- ls -la /var/lib/cloud/data/result.json; do
           sleep 1s

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -309,35 +309,15 @@ jobs:
         run: |
           JSON='${{ steps.pre_process_rules.outputs.docker_build_rules }}'
           LEGACY_DOCKER_TARGETS=$(echo $JSON | jq '.. | .crosstarget? | select(. != null)')
+
           JSON='${{ steps.pre_process_rules.outputs.docker_build_rules }}'
           DOCKER_TARGETS=$(echo $JSON | jq '.. | .target? | select(. != null)')
+
           JSON='${{ steps.pre_process_rules.outputs.package_build_rules }}'
           PKG_TARGETS=$(echo $JSON | jq '.. | .target? | select(. != null)')
 
-          if [ "${LEGACY_DOCKER_TARGETS}" == '""' ]; then
-            LEGACY_DOCKER_TARGETS=
-          fi
-          if [ "${DOCKER_TARGETS}" == '""' ]; then
-            DOCKER_TARGETS=
-          fi
-          if [ "${PKG_TARGETS}" == '""' ]; then
-            PKG_TARGETS=
-          fi
-
-          echo LEGACY_DOCKER_TARGETS
-          echo ${LEGACY_DOCKER_TARGETS}
-
-          echo DOCKER_TARGETS
-          echo ${DOCKER_TARGETS}
-
-          echo PKG_TARGETS
-          echo ${PKG_TARGETS}
-
           # This is a bit ridiculous invoking jq three times... there must be an easier way
           ALL_TARGETS=$(echo ${LEGACY_DOCKER_TARGETS} ${DOCKER_TARGETS} ${PKG_TARGETS} | jq -s 'flatten | unique | .[] | select(. != "x86_64")' | jq -s)
-
-          echo ALL_TARGETS
-          echo "${ALL_TARGETS}"
 
           echo "matrix<<END_OF_TARGETS" >> $GITHUB_OUTPUT
           if [ "${ALL_TARGETS}" == '[]' ]; then

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -671,8 +671,6 @@ jobs:
     # Install Rust the hard way rather than using a GH Action because the action doesn't work inside a Docker container.
     - name: Install Rust
       run: |
-        trap 'kill -term %%' SIGINT
-
         case ${OS_NAME} in
           debian|ubuntu)
             apt-get update
@@ -688,8 +686,6 @@ jobs:
 
     - name: Install compilation and other dependencies
       run: |
-        trap 'kill -term %%' SIGINT
-
         case ${OS_NAME} in
           debian|ubuntu)
             apt-get install -y binutils build-essential jq lintian pkg-config ${{ inputs.deb_extra_build_packages }}
@@ -1203,8 +1199,6 @@ jobs:
     - name: Prepare container
       shell: bash
       run: |
-        trap 'kill -term %%' SIGINT
-
         echo "Waiting for cloud-init.."
         while ! sudo lxc exec testcon -- ls -la /var/lib/cloud/data/result.json; do
           sleep 1s

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -320,7 +320,7 @@ jobs:
           echo PKG_TARGETS
           echo ${PKG_TARGETS}
 
-          ALL_TARGETS=(${LEGACY_DOCKER_TARGETS} ${DOCKER_TARGETS}) ${PKG_TARGETS})
+          ALL_TARGETS=(${LEGACY_DOCKER_TARGETS} ${DOCKER_TARGETS} ${PKG_TARGETS})
           JOINED_TARGETS=$(IFS=, ; echo "${ALL_TARGETS[*]}")
 
           echo JOINED_TARGETS

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -664,7 +664,7 @@ jobs:
     # Install Rust the hard way rather than using a GH Action because the action doesn't work inside a Docker container.
     - name: Install Rust
       run: |
-        trap 'kill -term %1 SIGINT
+        trap 'kill -term %1' SIGINT
 
         case ${OS_NAME} in
           debian|ubuntu)
@@ -681,7 +681,7 @@ jobs:
 
     - name: Install compilation and other dependencies
       run: |
-        trap 'kill -term %1 SIGINT
+        trap 'kill -term %1' SIGINT
 
         case ${OS_NAME} in
           debian|ubuntu)
@@ -1196,7 +1196,7 @@ jobs:
     - name: Prepare container
       shell: bash
       run: |
-        trap 'kill -term %1 SIGINT
+        trap 'kill -term %1' SIGINT
 
         echo "Waiting for cloud-init.."
         while ! sudo lxc exec testcon -- ls -la /var/lib/cloud/data/result.json; do

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -333,7 +333,8 @@ jobs:
           echo PKG_TARGETS
           echo ${PKG_TARGETS}
 
-          ALL_TARGETS=$(echo ${LEGACY_DOCKER_TARGETS} ${DOCKER_TARGETS} ${PKG_TARGETS} | jq -s 'flatten | unique | .[] | select(. != "x86_64") | [.]')
+          # This is a bit ridiculous invoking jq three times... there must be an easier way
+          ALL_TARGETS=$(echo ${LEGACY_DOCKER_TARGETS} ${DOCKER_TARGETS} ${PKG_TARGETS} | jq -s 'flatten | unique | .[] | select(. != "x86_64")' | jq -s)
 
           echo ALL_TARGETS
           echo "${ALL_TARGETS}"

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -130,7 +130,7 @@ on:
   workflow_call:
     inputs:
       cross_build_rules:
-        description: "Deprecated. Required cross compilation targets are automatically determined from the other inputs."
+        description: "This input is deprecated. Cross build targets will be determined automatically."
         required: false
         type: string
         default: ''

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -315,9 +315,9 @@ jobs:
             LEGACY_DOCKER_TARGETS=
           fi
           if [ "${DOCKER_TARGETS}" == '""' ]; then
-            LEGACY_DOCKER_TARGETS=
+            DOCKER_TARGETS=
           fi
-          if [ "${LEGACY_DOCKER_TARGETS}" == '""' ]; then
+          if [ "${PKG_TARGETS}" == '""' ]; then
             PKG_TARGETS=
           fi
 

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -337,7 +337,11 @@ jobs:
           echo "${JOINED_TARGETS}"
 
           echo "matrix<<END_OF_TARGETS" >> $GITHUB_OUTPUT
-          echo '{ "target": ['${JOINED_TARGETS}'] }' >> $GITHUB_OUTPUT
+          if [ "${JOINED_TARGETS}" == '' ]; then
+            echo '{}' >> $GITHUB_OUTPUT
+          else
+            echo '{ "target": ['${JOINED_TARGETS}'] }' >> $GITHUB_OUTPUT
+          fi
           echo 'END_OF_TARGETS' >> $GITHUB_OUTPUT
 
       - name: Print rules

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -308,11 +308,11 @@ jobs:
         id: determine_cross_build_rules
         run: |
           JSON='${{ steps.pre_process_rules.outputs.docker_build_rules }}'
-          LEGACY_DOCKER_TARGETS=$(echo $JSON | jq '.. | .crosstarget? | select(. != null) | jq -s 'flatten | unique'')
+          LEGACY_DOCKER_TARGETS=$(echo $JSON | jq '.. | .crosstarget? | select(. != null)' | jq -s 'flatten | unique')
           JSON='${{ steps.pre_process_rules.outputs.docker_build_rules }}'
-          DOCKER_TARGETS=$(echo $JSON | jq '.. | .target? | select(. != null) | jq -s 'flatten | unique'')
+          DOCKER_TARGETS=$(echo $JSON | jq '.. | .target? | select(. != null)' | jq -s 'flatten | unique')
           JSON='${{ steps.pre_process_rules.outputs.package_build_rules }}'
-          PKG_TARGETS=$(echo $JSON | jq '.. | .target? | select(. != null) | jq -s 'flatten | unique'')
+          PKG_TARGETS=$(echo $JSON | jq '.. | .target? | select(. != null)' | jq -s 'flatten | unique')
 
           if [ "${LEGACY_DOCKER_TARGETS}" == '""' ]; then
             LEGACY_DOCKER_TARGETS=

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -664,7 +664,7 @@ jobs:
     # Install Rust the hard way rather than using a GH Action because the action doesn't work inside a Docker container.
     - name: Install Rust
       run: |
-        trap 'kill -term %1' SIGINT
+        trap 'kill -term $$' SIGINT
 
         case ${OS_NAME} in
           debian|ubuntu)
@@ -681,7 +681,7 @@ jobs:
 
     - name: Install compilation and other dependencies
       run: |
-        trap 'kill -term %1' SIGINT
+        trap 'kill -term $$' SIGINT
 
         case ${OS_NAME} in
           debian|ubuntu)
@@ -1196,7 +1196,7 @@ jobs:
     - name: Prepare container
       shell: bash
       run: |
-        trap 'kill -term %1' SIGINT
+        trap 'kill -term $$' SIGINT
 
         echo "Waiting for cloud-init.."
         while ! sudo lxc exec testcon -- ls -la /var/lib/cloud/data/result.json; do

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -133,7 +133,7 @@ on:
         description: "Deprecated. Required cross compilation targets are automatically determined from the other inputs."
         required: false
         type: string
-        default: '{}'
+        default: ''
       package_build_rules:
         description: "A relative path to a YAML file, or a YAML string, containing a GitHub Actions matrix with 'pkg' (your app name), Docker 'image' (image <os>:<rel>), 'target' (x86_64, or a Rust target triple), 'extra_build_args' (optional), 'os' (optional) fields. See also: https://doc.rust-lang.org/nightly/rustc/platform-support.html"
         required: false
@@ -261,20 +261,18 @@ jobs:
       - name: Pre-process rules
         id: pre_process_rules
         run: |
-          echo "cross_build_rules<<END_OF_CROSS_BUILD_RULES" >> $GITHUB_OUTPUT
-          if [[ -f '${{ inputs.cross_build_rules }}' ]]; then
-            yq '${{ inputs.cross_build_rules }}' -p=yaml -o=json >> $GITHUB_OUTPUT
-          else
-            echo '${{ inputs.cross_build_rules }}' | yq -p=yaml -o=json >> $GITHUB_OUTPUT
+          if [[ '${{ inputs.cross_build_rules }}' != '' ]]; then
+            echo "::warning::The 'cross_build_rules' input is deprecated. Cross build targets will be determined automatically."
           fi
-          echo 'END_OF_CROSS_BUILD_RULES' >> $GITHUB_OUTPUT
 
           echo "docker_build_rules<<END_OF_DOCKER_BUILD_RULES" >> $GITHUB_OUTPUT
           if [[ -f '${{ inputs.docker_build_rules }}' ]]; then
-            yq '${{ inputs.docker_build_rules }}' -p=yaml -o=json >> $GITHUB_OUTPUT
+            JSON=$(yq '${{ inputs.docker_build_rules }}' -I=0 -p=yaml -o=json)
           else
-            echo '${{ inputs.docker_build_rules }}' | yq -p=yaml -o=json >> $GITHUB_OUTPUT
+            JSON=$(echo '${{ inputs.docker_build_rules }}' | yq -I=0 -p=yaml -o=json)
           fi
+          JSON=$(echo $JSON | jq '(.. | select(has("crosstarget")?)) |= with_entries(if .key == "crosstarget" then .key = "target" else . end)')
+          echo ${JSON} | jq >> $GITHUB_OUTPUT
           echo 'END_OF_DOCKER_BUILD_RULES' >> $GITHUB_OUTPUT
 
           echo "package_build_rules<<END_OF_PACKAGE_BUILD_RULES" >> $GITHUB_OUTPUT
@@ -308,16 +306,13 @@ jobs:
         id: determine_cross_build_rules
         run: |
           JSON='${{ steps.pre_process_rules.outputs.docker_build_rules }}'
-          LEGACY_DOCKER_TARGETS=$(echo $JSON | jq '.. | .crosstarget? | select(. != null)')
-
-          JSON='${{ steps.pre_process_rules.outputs.docker_build_rules }}'
           DOCKER_TARGETS=$(echo $JSON | jq '.. | .target? | select(. != null)')
 
           JSON='${{ steps.pre_process_rules.outputs.package_build_rules }}'
           PKG_TARGETS=$(echo $JSON | jq '.. | .target? | select(. != null)')
 
           # This is a bit ridiculous invoking jq three times... there must be an easier way
-          ALL_TARGETS=$(echo ${LEGACY_DOCKER_TARGETS} ${DOCKER_TARGETS} ${PKG_TARGETS} | jq -s 'flatten | unique | .[] | select(. != "x86_64")' | jq -s)
+          ALL_TARGETS=$(echo ${DOCKER_TARGETS} ${PKG_TARGETS} | jq -s 'flatten | unique | .[] | select(. != "x86_64")' | jq -s)
 
           echo "matrix<<END_OF_TARGETS" >> $GITHUB_OUTPUT
           if [ "${ALL_TARGETS}" == '[]' ]; then

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -664,7 +664,7 @@ jobs:
     # Install Rust the hard way rather than using a GH Action because the action doesn't work inside a Docker container.
     - name: Install Rust
       run: |
-        trap 'kill -term $$' SIGINT
+        trap 'kill -term %%' SIGINT
 
         case ${OS_NAME} in
           debian|ubuntu)
@@ -681,7 +681,7 @@ jobs:
 
     - name: Install compilation and other dependencies
       run: |
-        trap 'kill -term $$' SIGINT
+        trap 'kill -term %%' SIGINT
 
         case ${OS_NAME} in
           debian|ubuntu)
@@ -1196,7 +1196,7 @@ jobs:
     - name: Prepare container
       shell: bash
       run: |
-        trap 'kill -term $$' SIGINT
+        trap 'kill -term %%' SIGINT
 
         echo "Waiting for cloud-init.."
         while ! sudo lxc exec testcon -- ls -la /var/lib/cloud/data/result.json; do

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -308,11 +308,11 @@ jobs:
         id: determine_cross_build_rules
         run: |
           JSON='${{ steps.pre_process_rules.outputs.docker_build_rules }}'
-          LEGACY_DOCKER_TARGETS=$(echo $JSON | jq '.. | .crosstarget? | select(. != null)' | jq -s 'flatten | unique')
+          LEGACY_DOCKER_TARGETS=$(echo $JSON | jq '.. | .crosstarget? | select(. != null)')
           JSON='${{ steps.pre_process_rules.outputs.docker_build_rules }}'
-          DOCKER_TARGETS=$(echo $JSON | jq '.. | .target? | select(. != null)' | jq -s 'flatten | unique')
+          DOCKER_TARGETS=$(echo $JSON | jq '.. | .target? | select(. != null)')
           JSON='${{ steps.pre_process_rules.outputs.package_build_rules }}'
-          PKG_TARGETS=$(echo $JSON | jq '.. | .target? | select(. != null)' | jq -s 'flatten | unique')
+          PKG_TARGETS=$(echo $JSON | jq '.. | .target? | select(. != null)')
 
           if [ "${LEGACY_DOCKER_TARGETS}" == '""' ]; then
             LEGACY_DOCKER_TARGETS=
@@ -333,7 +333,7 @@ jobs:
           echo PKG_TARGETS
           echo ${PKG_TARGETS}
 
-          ALL_TARGETS=(${LEGACY_DOCKER_TARGETS} ${DOCKER_TARGETS} ${PKG_TARGETS})
+          ALL_TARGETS=$(echo ${LEGACY_DOCKER_TARGETS} ${DOCKER_TARGETS} ${PKG_TARGETS} | jq -s 'flatten | unique | .[]')
           JOINED_TARGETS=$(IFS=, ; echo "${ALL_TARGETS[*]}")
 
           echo JOINED_TARGETS

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -308,11 +308,11 @@ jobs:
         id: determine_cross_build_rules
         run: |
           JSON='${{ steps.pre_process_rules.outputs.docker_build_rules }}'
-          LEGACY_DOCKER_TARGETS=$(echo $JSON | jq '.. | .crosstarget? | select(. != null)')
+          LEGACY_DOCKER_TARGETS=$(echo $JSON | jq '.. | .crosstarget? | select(. != null) | jq -s 'flatten | unique'')
           JSON='${{ steps.pre_process_rules.outputs.docker_build_rules }}'
-          LEGACY_DOCKER_TARGETS=$(echo $JSON | jq '.. | .target? | select(. != null)')
+          DOCKER_TARGETS=$(echo $JSON | jq '.. | .target? | select(. != null) | jq -s 'flatten | unique'')
           JSON='${{ steps.pre_process_rules.outputs.package_build_rules }}'
-          PKG_TARGETS=$(echo $JSON | jq '.. | .target? | select(. != null)')
+          PKG_TARGETS=$(echo $JSON | jq '.. | .target? | select(. != null) | jq -s 'flatten | unique'')
 
           if [ "${LEGACY_DOCKER_TARGETS}" == '""' ]; then
             LEGACY_DOCKER_TARGETS=

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -318,7 +318,9 @@ jobs:
           if [ "${ALL_TARGETS}" == '[]' ]; then
             echo '{}' >> $GITHUB_OUTPUT
           else
-            echo '{ "target": '${ALL_TARGETS}' }' >> $GITHUB_OUTPUT
+            echo '{ "target": ' >> $GITHUB_OUTPUT
+            echo ${ALL_TARGETS} | jq
+            echo '}' >> $GITHUB_OUTPUT
           fi
           echo 'END_OF_TARGETS' >> $GITHUB_OUTPUT
 

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -307,9 +307,12 @@ jobs:
       - name: Determine cross build rules
         id: determine_cross_build_rules
         run: |
-          LEGACY_DOCKER_TARGETS=$(echo ${{ steps.pre_process_rules.outputs.docker_build_rules }} | jq '.. | .crosstarget? | select(. != null)')
-          DOCKER_TARGETS=$(echo ${{ steps.pre_process_rules.outputs.docker_build_rules }} | jq '.. | .target? | select(. != null)')
-          PKG_TARGETS=$(echo ${{ steps.pre_process_rules.outputs.package_build_rules }} | jq '.. | .target? | select(. != null)')
+          JSON='${{ steps.pre_process_rules.outputs.docker_build_rules }}'
+          LEGACY_DOCKER_TARGETS=$(echo $JSON | jq '.. | .crosstarget? | select(. != null)')
+          JSON='${{ steps.pre_process_rules.outputs.docker_build_rules }}'
+          LEGACY_DOCKER_TARGETS=$(echo $JSON | jq '.. | .target? | select(. != null)')
+          JSON='${{ steps.pre_process_rules.outputs.package_build_rules }}'
+          PKG_TARGETS=$(echo $JSON | jq '.. | .target? | select(. != null)')
 
           if [ "${LEGACY_DOCKER_TARGETS}" == '""' ]; then
             LEGACY_DOCKER_TARGETS=

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -326,7 +326,7 @@ jobs:
           echo JOINED_TARGETS
           echo "${JOINED_TARGETS}"
 
-          echo "matrix=<<END_OF_TARGETS" >> $GITHUB_OUTPUT
+          echo "matrix<<END_OF_TARGETS" >> $GITHUB_OUTPUT
           echo '{ "target": ['${JOINED_TARGETS}'] }' >> $GITHUB_OUTPUT
           echo 'END_OF_TARGETS' >> $GITHUB_OUTPUT
 

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -307,9 +307,9 @@ jobs:
       - name: Determine cross build rules
         id: determine_cross_build_rules
         run: |
-          LEGACY_DOCKER_TARGETS='"${{ join(fromJSON(steps.pre_process_rules.outputs.docker_build_rules).*.crosstarget, '","') }}"'
-          DOCKER_TARGETS='"${{ join(fromJSON(steps.pre_process_rules.outputs.docker_build_rules).*.target, '","') }}"'
-          PKG_TARGETS='"${{ join(fromJSON(steps.pre_process_rules.outputs.package_build_rules).*.target, '","') }}"'
+          LEGACY_DOCKER_TARGETS=$(echo ${{ steps.pre_process_rules.outputs.docker_build_rules }} | jq '.. | .crosstarget? | select(. != null)')
+          DOCKER_TARGETS=$(echo ${{ steps.pre_process_rules.outputs.docker_build_rules }} | jq '.. | .target? | select(. != null)')
+          PKG_TARGETS=$(echo ${{ steps.pre_process_rules.outputs.package_build_rules }} | jq '.. | .target? | select(. != null)')
 
           if [ "${LEGACY_DOCKER_TARGETS}" == '""' ]; then
             LEGACY_DOCKER_TARGETS=

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -333,17 +333,16 @@ jobs:
           echo PKG_TARGETS
           echo ${PKG_TARGETS}
 
-          ALL_TARGETS=$(echo ${LEGACY_DOCKER_TARGETS} ${DOCKER_TARGETS} ${PKG_TARGETS} | jq -s 'flatten | unique | .[]')
-          JOINED_TARGETS=$(IFS=, ; echo "${ALL_TARGETS[*]}")
+          ALL_TARGETS=$(echo ${LEGACY_DOCKER_TARGETS} ${DOCKER_TARGETS} ${PKG_TARGETS} | jq -s 'flatten | unique')
 
-          echo JOINED_TARGETS
-          echo "${JOINED_TARGETS}"
+          echo ALL_TARGETS
+          echo "${ALL_TARGETS}"
 
           echo "matrix<<END_OF_TARGETS" >> $GITHUB_OUTPUT
-          if [ "${JOINED_TARGETS}" == '' ]; then
+          if [ "${ALL_TARGETS}" == '[]' ]; then
             echo '{}' >> $GITHUB_OUTPUT
           else
-            echo '{ "target": ['${JOINED_TARGETS}'] }' >> $GITHUB_OUTPUT
+            echo '{ "target": '${ALL_TARGETS}' }' >> $GITHUB_OUTPUT
           fi
           echo 'END_OF_TARGETS' >> $GITHUB_OUTPUT
 

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -333,7 +333,7 @@ jobs:
           echo PKG_TARGETS
           echo ${PKG_TARGETS}
 
-          ALL_TARGETS=$(echo ${LEGACY_DOCKER_TARGETS} ${DOCKER_TARGETS} ${PKG_TARGETS} | jq -s 'flatten | unique')
+          ALL_TARGETS=$(echo ${LEGACY_DOCKER_TARGETS} ${DOCKER_TARGETS} ${PKG_TARGETS} | jq -s 'flatten | unique | .[] | select(. != "x86_64") | [.]')
 
           echo ALL_TARGETS
           echo "${ALL_TARGETS}"

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -130,7 +130,7 @@ on:
   workflow_call:
     inputs:
       cross_build_rules:
-        description: "A relative path to a YAML file, or a YAML string, containing a GitHub Actions matrix with field cross-compilation 'target's, e.g. arm-unknown-linux-musleabihf."
+        description: "Deprecated. Required cross compilation targets are automatically determined from the other inputs."
         required: false
         type: string
         default: '{}'
@@ -169,7 +169,7 @@ on:
         type: string
         default: './Dockerfile'
       docker_build_rules:
-        description: "A relative path to a YAML file, or a YAML string, containing a GitHub Actions matrix with platform, shortname, crosstarget (required if mode is copy), mode (optional: build (default) or copy) and cargo_args (optional) fields."
+        description: "A relative path to a YAML file, or a YAML string, containing a GitHub Actions matrix with platform, shortname, target (required if mode is copy), mode (optional: build (default) or copy) and cargo_args (optional) fields."
         required: false
         type: string
         default: '{}'
@@ -250,7 +250,7 @@ jobs:
       all_repo_and_tag_pairs: ${{ steps.encode.outputs.all_repo_and_tag_pairs }}
       first_repo_and_tag_pair: ${{ steps.encode.outputs.first_repo_and_tag_pair }}
       lower_docker_org: ${{ steps.encode.outputs.lower_docker_org }}
-      cross_build_rules: ${{ steps.pre_process_rules.outputs.cross_build_rules }}
+      cross_build_rules: ${{ steps.determine_cross_build_rules.outputs.matrix }}
       docker_build_rules: ${{ steps.pre_process_rules.outputs.docker_build_rules }}
       package_build_rules: ${{ steps.pre_process_rules.outputs.package_build_rules }}
       package_test_rules: ${{ steps.pre_process_rules.outputs.package_test_rules }}
@@ -304,6 +304,32 @@ jobs:
           echo ${JSON} | jq >> $GITHUB_OUTPUT
           echo 'END_OF_PACKAGE_TEST_RULES' >> $GITHUB_OUTPUT
 
+      - name: Determine cross build rules
+        id: determine_cross_build_rules
+        run: |
+          LEGACY_DOCKER_TARGETS='"${{ join(fromJSON(steps.pre_process_rules.outputs.docker_build_rules).*.crosstarget, '","') }}"'
+          DOCKER_TARGETS='"${{ join(fromJSON(steps.pre_process_rules.outputs.docker_build_rules).*.target, '","') }}"'
+          PKG_TARGETS='"${{ join(fromJSON(steps.pre_process_rules.outputs.package_build_rules).*.target, '","') }}"'
+
+          echo LEGACY_DOCKER_TARGETS
+          echo ${LEGACY_DOCKER_TARGETS}
+
+          echo DOCKER_TARGETS
+          echo ${DOCKER_TARGETS}
+
+          echo PKG_TARGETS
+          echo ${PKG_TARGETS}
+
+          ALL_TARGETS=(${LEGACY_DOCKER_TARGETS} ${DOCKER_TARGETS}) ${PKG_TARGETS})
+          JOINED_TARGETS=$(IFS=, ; echo "${ALL_TARGETS[*]}")
+
+          echo JOINED_TARGETS
+          echo "${JOINED_TARGETS}"
+
+          echo "matrix=<<END_OF_TARGETS" >> $GITHUB_OUTPUT
+          echo '{ "target": ['${JOINED_TARGETS}'] }' >> $GITHUB_OUTPUT
+          echo 'END_OF_TARGETS' >> $GITHUB_OUTPUT
+
       - name: Print rules
         # Disable default use of bash -x for easier to read output in the log
         shell: bash
@@ -311,9 +337,9 @@ jobs:
           echo "============================================================================="
           echo "Cross build rules:"
           echo "============================================================================="
-          JSON='${{ steps.pre_process_rules.outputs.cross_build_rules }}'
+          JSON='${{ steps.determine_cross_build_rules.outputs.matrix }}'
           if [[ "${JSON}" != "{}" ]]; then
-            echo '${{ steps.pre_process_rules.outputs.cross_build_rules }}'
+            echo '${{ steps.determine_cross_build_rules.outputs.matrix }}'
           else
             echo None
           fi
@@ -1395,7 +1421,7 @@ jobs:
         if: ${{ steps.verify.outputs.mode == 'copy' }}
         uses: actions/download-artifact@v3
         with:
-          name: tmp-cross-binaries-${{ matrix.crosstarget }}
+          name: tmp-cross-binaries-${{ matrix.target }}
           # The file downloaded to dockerbin/xxx will be used by the Dockerfile
           # Note: matrix.platform here has to match the Docker BuildX $TARGETPLATFORM variable available while building
           # the Dockerfile, e.g. linux/amd64.

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -311,6 +311,16 @@ jobs:
           DOCKER_TARGETS='"${{ join(fromJSON(steps.pre_process_rules.outputs.docker_build_rules).*.target, '","') }}"'
           PKG_TARGETS='"${{ join(fromJSON(steps.pre_process_rules.outputs.package_build_rules).*.target, '","') }}"'
 
+          if [ "${LEGACY_DOCKER_TARGETS}" == '""' ]; then
+            LEGACY_DOCKER_TARGETS=
+          fi
+          if [ "${DOCKER_TARGETS}" == '""' ]; then
+            LEGACY_DOCKER_TARGETS=
+          fi
+          if [ "${LEGACY_DOCKER_TARGETS}" == '""' ]; then
+            PKG_TARGETS=
+          fi
+
           echo LEGACY_DOCKER_TARGETS
           echo ${LEGACY_DOCKER_TARGETS}
 


### PR DESCRIPTION
There's no need for users to have to manually specify the cross-compilation targets, they can be determined from the `docker_build_rules` and `pkg_build_rules` inputs, specifcally from the `target` field of those inputs.

This PR:
- Automates determination of the cross build targets.
- Deprecates the `cross_build_rules` input.
- Supports `target` as a field of `docker_build_rules` for consistency with the `pkg_build_rules` input and deprecates the `crosstarget` field.

This PR is backward compatible.