### PR TITLE
Parallelize cross and normal compilation.

### DIFF
--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -763,9 +763,9 @@ jobs:
         retry-exempt-status-codes: 400,401
         script: |
           github.rest.actions.listWorkflowRunArtifacts({
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            run_id: github.run_id,
+            owner: ${{ github.repository_owner }},
+            repo: ${{ github.repository }},
+            run_id: ${{ github.run_id }},
           });
   
     - name: Untar the set of downloaded binaries

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -694,14 +694,14 @@ jobs:
             curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=./githubcli-archive-keyring.gpg
             apt-key add ./githubcli-archive-keyring.gpg
             apt-get update
-            apt-get install -y binutils dpkg-dev gcc gh jq lintian pkg-config ${{ inputs.deb_extra_build_packages }}
+            apt-get install -y binutils dpkg-dev gcc gh gnupg jq lintian pkg-config ${{ inputs.deb_extra_build_packages }}
             ;;
           centos)
             sed -i -e 's/enabled=1/enabled=0/' /etc/yum/pluginconf.d/fastestmirror.conf || true
             yum install epel-release -y
             yum install 'dnf-command(config-manager)'
             yum config-manager --add-repo http://cli.github.com/packages/rpm/gh-cli.repo
-            yum install -y findutils gcc gh jq rpmlint ${{ inputs.rpm_extra_build_packages }}
+            yum install -y findutils gcc gh gpg jq rpmlint ${{ inputs.rpm_extra_build_packages }}
             ;;
         esac
 

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -763,8 +763,8 @@ jobs:
         retry-exempt-status-codes: 400,401
         script: |
           github.rest.actions.listWorkflowRunArtifacts({
-            owner: ${{ github.repository_owner }},
-            repo: ${{ github.repository }},
+            owner: context.repo.owner,
+            repo: context.repo.repo,
             run_id: ${{ github.run_id }},
           });
   

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -754,7 +754,7 @@ jobs:
             ;;
         esac
 
-    - name: Download cross compiled binaries
+    - name: Wait for cross-compilation
       if: ${{ matrix.target != 'x86_64' }}
       uses: actions/github-script@v6
       with:
@@ -762,11 +762,18 @@ jobs:
         retries: 3
         retry-exempt-status-codes: 400,401
         script: |
-          github.rest.actions.listWorkflowRunArtifacts({
+          console.log(github.rest.actions.listWorkflowRunArtifacts({
             owner: context.repo.owner,
             repo: context.repo.repo,
             run_id: ${{ github.run_id }},
-          });
+          }));
+
+    - name: Download cross-compiled binaries
+      if: ${{ matrix.target != 'x86_64' }}
+      uses: actions/download-artifact@v3
+      with:
+        name: tmp-cross-binaries-${{ matrix.target }}
+        path: .
   
     - name: Untar the set of downloaded binaries
       if: ${{ matrix.target != 'x86_64' }}

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -697,6 +697,7 @@ jobs:
             apt-get update
             apt-get install -y binutils dpkg-dev gcc gh jq lintian pkg-config ${{ inputs.deb_extra_build_packages }}
             ;;
+
           centos)
             sed -i -e 's/enabled=1/enabled=0/' /etc/yum/pluginconf.d/fastestmirror.conf || true
             yum install -y epel-release
@@ -704,6 +705,7 @@ jobs:
               7)
                 yum install -y yum-utils
                 yum-config-manager --add-repo=https://cli.github.com/packages/rpm/gh-cli.repo
+                ;;
                 
               8)
                 yum install -y 'dnf-command(config-manager)'

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -769,6 +769,7 @@ jobs:
 
     - name: Download cross compiled binaries
       if: ${{ matrix.target != 'x86_64' }}
+      uses: actions/download-artifact@v3
       with:
         name: tmp-cross-binaries-${{ matrix.target }}
         path: .

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -699,7 +699,7 @@ jobs:
             ;;
           centos)
             sed -i -e 's/enabled=1/enabled=0/' /etc/yum/pluginconf.d/fastestmirror.conf || true
-            yum install -yepel-release
+            yum install -y epel-release
             yum install -y 'dnf-command(config-manager)'
             yum config-manager --add-repo http://cli.github.com/packages/rpm/gh-cli.repo
             yum install -y findutils gcc gh jq rpmlint ${{ inputs.rpm_extra_build_packages }}

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -700,8 +700,16 @@ jobs:
           centos)
             sed -i -e 's/enabled=1/enabled=0/' /etc/yum/pluginconf.d/fastestmirror.conf || true
             yum install -y epel-release
-            yum install -y 'dnf-command(config-manager)'
-            yum config-manager --add-repo http://cli.github.com/packages/rpm/gh-cli.repo
+            case ${OS_REL} in
+              7)
+                yum install -y yum-utils
+                yum-config-manager --add-repo=https://cli.github.com/packages/rpm/gh-cli.repo
+                
+              8)
+                yum install -y 'dnf-command(config-manager)'
+                yum config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo
+                ;;
+            esac
             yum install -y findutils gcc gh jq rpmlint ${{ inputs.rpm_extra_build_packages }}
             ;;
         esac

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -585,7 +585,8 @@ jobs:
   pkg:
     # Use of always() here ensures that even if the cross job is skipped we will still run
     if: ${{ always() && needs.prepare.outputs.package_build_rules != '{}' }}
-    needs: [cross, prepare]
+    # needs: [cross, prepare]
+    needs: prepare
     runs-on: ubuntu-latest
     # Build on the platform we are targeting in order to avoid https://github.com/rust-lang/rust/issues/57497.
     # Specifying container causes all of the steps in this job to run inside a Docker container (which is why the
@@ -755,10 +756,14 @@ jobs:
 
     - name: Download cross compiled binaries
       if: ${{ matrix.target != 'x86_64' }}
-      uses: actions/download-artifact@v3
+      uses: Wandelen/wretry.action@v1
       with:
-        name: tmp-cross-binaries-${{ matrix.target }}
-        path: .
+        action: actions/download-artifact@v3
+        with: |
+          name: tmp-cross-binaries-${{ matrix.target }}
+          path: .
+        attempt_limit: 120
+        attempt_delay: 5000
   
     - name: Untar the set of downloaded binaries
       if: ${{ matrix.target != 'x86_64' }}

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -755,10 +755,13 @@ jobs:
         esac
 
     - name: Wait for cross-compilation
+      if: ${{ matrix.target != 'x86_64' }}
       uses: yogeshlonkar/wait-for-jobs@v0
       with:
         gh-token: ${{ secrets.GITHUB_TOKEN }}
         jobs: cross
+        interval: 30000
+        ttl: 10
 
     - name: Download cross-compiled binaries
       if: ${{ matrix.target != 'x86_64' }}

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -779,8 +779,9 @@ jobs:
         MAX_RETRIES=120
         DELAY_SECS=5
         RETRY_N=1
+        REPO=${{ github.repository }}
         while [ $RETRY_N -lt $MAX_RETRIES ]; do
-          gh run download ${{ github.run_id }} --name tmp-cross-binaries-${{ matrix.target }} && exit 0
+          gh run download ${{ github.run_id }} --repo $REPO --name tmp-cross-binaries-${{ matrix.target }} && exit 0
           RETRY_N=$(( $RETRY_N + 1 ))
           sleep $DELAY_SECS
         done

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -695,7 +695,7 @@ jobs:
             curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=./githubcli-archive-keyring.gpg
             apt-key add ./githubcli-archive-keyring.gpg
             apt-get update
-            apt-get install -y binutils dpkg-dev gcc ghjq lintian pkg-config ${{ inputs.deb_extra_build_packages }}
+            apt-get install -y binutils dpkg-dev gcc gh jq lintian pkg-config ${{ inputs.deb_extra_build_packages }}
             ;;
           centos)
             sed -i -e 's/enabled=1/enabled=0/' /etc/yum/pluginconf.d/fastestmirror.conf || true

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -690,12 +690,18 @@ jobs:
       run: |
         case ${OS_NAME} in
           debian|ubuntu)
-            apt-get install -y binutils gcc dpkg-dev jq lintian pkg-config ${{ inputs.deb_extra_build_packages }}
+            curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
+            chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg
+            echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null
+            apt-get update
+            apt-get install -y binutils dpkg-dev gcc gh jq lintian pkg-config ${{ inputs.deb_extra_build_packages }}
             ;;
           centos)
             sed -i -e 's/enabled=1/enabled=0/' /etc/yum/pluginconf.d/fastestmirror.conf || true
             yum install epel-release -y
-            yum install -y findutils gcc jq rpmlint ${{ inputs.rpm_extra_build_packages }}
+            yum install 'dnf-command(config-manager)'
+            yum config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo
+            yum install -y findutils gcc gh jq rpmlint ${{ inputs.rpm_extra_build_packages }}
             ;;
         esac
 

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -690,9 +690,9 @@ jobs:
       run: |
         case ${OS_NAME} in
           debian|ubuntu)
-            curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
-            chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg
-            echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] http://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null
+            echo "deb http://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null
+            curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=./githubcli-archive-keyring.gpg
+            apt-key add ./githubcli-archive-keyring.gpg
             apt-get update
             apt-get install -y binutils dpkg-dev gcc gh jq lintian pkg-config ${{ inputs.deb_extra_build_packages }}
             ;;

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -543,7 +543,6 @@ jobs:
   #
   # See: https://github.com/rust-embedded/cross#docker-in-docker
   cross:
-    name: cross-${{ matrix.target }}
     if: ${{ needs.prepare.outputs.cross_build_rules != '{}' }}
     needs: prepare
     runs-on: ubuntu-20.04
@@ -566,9 +565,6 @@ jobs:
       if: ${{ steps.cache-cargo-cross.outputs.cache-hit != 'true' }}
       run: |
         cargo install cross
-
-    - name: Go slow while testing
-      run: sleep 75s
 
     - name: Cross compile
       run: |
@@ -601,7 +597,6 @@ jobs:
   pkg:
     # Use of always() here ensures that even if the cross job is skipped we will still run
     if: ${{ always() && needs.prepare.outputs.package_build_rules != '{}' }}
-    # needs: [cross, prepare]
     needs: prepare
     runs-on: ubuntu-latest
     # Build on the platform we are targeting in order to avoid https://github.com/rust-lang/rust/issues/57497.

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -754,6 +754,11 @@ jobs:
             ;;
         esac
 
+    - name: Sleep
+      uses: juliangruber/sleep-action@v1
+      with:
+        time: 120s
+
     - name: Wait for cross-compilation
       id: waitcross
       if: ${{ matrix.target != 'x86_64' }}

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -134,6 +134,11 @@ on:
         required: false
         type: string
         default: ''
+      cross_max_wait_mins:
+        description: "The maximum number of minutes the pkg and/or docker builds will wait for the cross-compiled artifact to become available. Defaults to 10 minutes."
+        required: false
+        type: string
+        default: '10'
       package_build_rules:
         description: "A relative path to a YAML file, or a YAML string, containing a GitHub Actions matrix with 'pkg' (your app name), Docker 'image' (image <os>:<rel>), 'target' (x86_64, or a Rust target triple), 'extra_build_args' (optional), 'os' (optional) fields. See also: https://doc.rust-lang.org/nightly/rustc/platform-support.html"
         required: false
@@ -278,6 +283,8 @@ jobs:
       first_repo_and_tag_pair: ${{ steps.encode.outputs.first_repo_and_tag_pair }}
       lower_docker_org: ${{ steps.encode.outputs.lower_docker_org }}
       cross_build_rules: ${{ steps.determine_cross_build_rules.outputs.matrix }}
+      cross_max_wait_ms: ${{ steps.determine_cross_build_rules.outputs.max_wait_ms }}
+      cross_retry_delay_ms: ${{ steps.determine_cross_build_rules.outputs.retry_delay_ms }}
       docker_build_rules: ${{ steps.pre_process_rules.outputs.docker_build_rules }}
       package_build_rules: ${{ steps.pre_process_rules.outputs.package_build_rules }}
       package_test_rules: ${{ steps.pre_process_rules.outputs.package_test_rules }}
@@ -348,6 +355,10 @@ jobs:
             echo '{ "target": ' ${ALL_TARGETS} '}' | jq >> $GITHUB_OUTPUT
           fi
           echo 'END_OF_TARGETS' >> $GITHUB_OUTPUT
+
+          RETRY_DELAY_MS=30000
+          echo "retry_delay_ms=${RETRY_DELAY_MS}"
+          echo "max_wait_ms=" $(( ( ${{ inputs.cross_max_wait_mins }} * 60 * 1000) / ${RETRY_DELAY_MS} ))
 
       - name: Print rules
         # Disable default use of bash -x for easier to read output in the log
@@ -764,8 +775,8 @@ jobs:
       with:
         name: tmp-cross-binaries-${{ matrix.target }}
         path: .
-        maxTries: 20
-        retryDelayMs: 30000
+        maxTries: ${{ needs.prepare.outputs.cross_max_wait_ms }}
+        retryDelayMs: ${{ needs.prepare.outputs.cross_retry_delay_ms }}
   
     - name: Untar the set of downloaded binaries
       if: ${{ matrix.target != 'x86_64' }}
@@ -1459,8 +1470,8 @@ jobs:
           # Note: matrix.platform here has to match the Docker BuildX $TARGETPLATFORM variable available while building
           # the Dockerfile, e.g. linux/amd64.
           path: dockerbin/${{ matrix.platform }}
-          maxTries: 20
-          retryDelayMs: 30000
+          maxTries: ${{ needs.prepare.outputs.cross_max_wait_ms }}
+          retryDelayMs: ${{ needs.prepare.outputs.cross_retry_delay_ms }}
 
       - name: Untar the set of downloaded binaries
         if: ${{ steps.verify.outputs.mode == 'copy' }}

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -1452,7 +1452,7 @@ jobs:
 
       - name: Download cross compiled binaries
         if: ${{ steps.verify.outputs.mode == 'copy' }}
-        uses: actions/download-artifact@v3
+        uses: ximon18/download-artifact@v3
         with:
           name: tmp-cross-binaries-${{ matrix.target }}
           # The file downloaded to dockerbin/xxx will be used by the Dockerfile

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -690,18 +690,19 @@ jobs:
       run: |
         case ${OS_NAME} in
           debian|ubuntu)
+            apt-get install -y gnupg 
             echo "deb http://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null
             curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=./githubcli-archive-keyring.gpg
             apt-key add ./githubcli-archive-keyring.gpg
             apt-get update
-            apt-get install -y binutils dpkg-dev gcc gh gnupg jq lintian pkg-config ${{ inputs.deb_extra_build_packages }}
+            apt-get install -y binutils dpkg-dev gcc ghjq lintian pkg-config ${{ inputs.deb_extra_build_packages }}
             ;;
           centos)
             sed -i -e 's/enabled=1/enabled=0/' /etc/yum/pluginconf.d/fastestmirror.conf || true
             yum install epel-release -y
             yum install 'dnf-command(config-manager)'
             yum config-manager --add-repo http://cli.github.com/packages/rpm/gh-cli.repo
-            yum install -y findutils gcc gh gpg jq rpmlint ${{ inputs.rpm_extra_build_packages }}
+            yum install -y findutils gcc gh jq rpmlint ${{ inputs.rpm_extra_build_packages }}
             ;;
         esac
 

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -690,12 +690,12 @@ jobs:
       run: |
         case ${OS_NAME} in
           debian|ubuntu)
-            apt-get install -y binutils gcc dpkg-dev jq lintian pkg-config ${{ inputs.deb_extra_build_packages }}
+            apt-get install -y binutils gcc dpkg-dev git jq lintian pkg-config ${{ inputs.deb_extra_build_packages }}
             ;;
           centos)
             sed -i -e 's/enabled=1/enabled=0/' /etc/yum/pluginconf.d/fastestmirror.conf || true
             yum install epel-release -y
-            yum install -y findutils gcc jq rpmlint ${{ inputs.rpm_extra_build_packages }}
+            yum install -y findutils gcc git jq rpmlint ${{ inputs.rpm_extra_build_packages }}
             ;;
         esac
 

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -764,6 +764,8 @@ jobs:
       with:
         name: tmp-cross-binaries-${{ matrix.target }}
         path: .
+        maxTries: 20
+        retryDelayMs: 30000
   
     - name: Untar the set of downloaded binaries
       if: ${{ matrix.target != 'x86_64' }}

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -699,8 +699,8 @@ jobs:
             ;;
           centos)
             sed -i -e 's/enabled=1/enabled=0/' /etc/yum/pluginconf.d/fastestmirror.conf || true
-            yum install epel-release -y
-            yum install 'dnf-command(config-manager)'
+            yum install -yepel-release
+            yum install -y 'dnf-command(config-manager)'
             yum config-manager --add-repo http://cli.github.com/packages/rpm/gh-cli.repo
             yum install -y findutils gcc gh jq rpmlint ${{ inputs.rpm_extra_build_packages }}
             ;;

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -760,7 +760,7 @@ jobs:
 
     - name: Download cross-compiled binaries
       if: ${{ matrix.target != 'x86_64' }}
-      uses: ximon18/download-artifact@a76002bf051c84e958e35e7f526f6f6e1b6f6e01
+      uses: ximon18/download-artifact@testing
       with:
         name: tmp-cross-binaries-${{ matrix.target }}
         path: .

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -763,6 +763,8 @@ jobs:
 
     - name: Wait for cross compilation
       if: ${{ matrix.target != 'x86_64' }}
+      env:
+        GH_TOKEN: ${{ github.token }}
       run: |
         MAX_RETRIES=120
         DELAY_SECS=5

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -755,18 +755,9 @@ jobs:
             ;;
         esac
 
-    - name: Wait for cross-compilation
-      if: ${{ matrix.target != 'x86_64' }}
-      uses: yogeshlonkar/wait-for-jobs@v0
-      with:
-        gh-token: ${{ secrets.GITHUB_TOKEN }}
-        jobs: cross-${{ matrix.target }}
-        interval: 30000
-        ttl: 10
-
     - name: Download cross-compiled binaries
       if: ${{ matrix.target != 'x86_64' }}
-      uses: actions/download-artifact@v3
+      uses: ximon18/download-artifact@testing
       with:
         name: tmp-cross-binaries-${{ matrix.target }}
         path: .

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -690,29 +690,12 @@ jobs:
       run: |
         case ${OS_NAME} in
           debian|ubuntu)
-            apt-get install -y apt-transport-https gnupg 
-            echo "deb https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null
-            curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=./githubcli-archive-keyring.gpg
-            apt-key add ./githubcli-archive-keyring.gpg
-            apt-get update
-            apt-get install -y binutils dpkg-dev gcc gh jq lintian pkg-config ${{ inputs.deb_extra_build_packages }}
+            apt-get install -y binutils gcc dpkg-dev jq lintian pkg-config ${{ inputs.deb_extra_build_packages }}
             ;;
-
           centos)
             sed -i -e 's/enabled=1/enabled=0/' /etc/yum/pluginconf.d/fastestmirror.conf || true
-            yum install -y epel-release
-            case ${OS_REL} in
-              7)
-                yum install -y yum-utils
-                yum-config-manager --add-repo=https://cli.github.com/packages/rpm/gh-cli.repo
-                ;;
-                
-              8)
-                yum install -y 'dnf-command(config-manager)'
-                yum config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo
-                ;;
-            esac
-            yum install -y findutils gcc gh jq rpmlint ${{ inputs.rpm_extra_build_packages }}
+            yum install epel-release -y
+            yum install -y findutils gcc jq rpmlint ${{ inputs.rpm_extra_build_packages }}
             ;;
         esac
 
@@ -771,28 +754,19 @@ jobs:
             ;;
         esac
 
-    - name: Wait for cross compilation
-      if: ${{ matrix.target != 'x86_64' }}
-      env:
-        GH_TOKEN: ${{ github.token }}
-      run: |
-        MAX_RETRIES=120
-        DELAY_SECS=5
-        RETRY_N=1
-        REPO=${{ github.repository }}
-        while [ $RETRY_N -lt $MAX_RETRIES ]; do
-          gh run download ${{ github.run_id }} --repo $REPO --name tmp-cross-binaries-${{ matrix.target }} && exit 0
-          RETRY_N=$(( $RETRY_N + 1 ))
-          sleep $DELAY_SECS
-        done
-        exit 1
-
     - name: Download cross compiled binaries
       if: ${{ matrix.target != 'x86_64' }}
-      uses: actions/download-artifact@v3
+      uses: actions/github-script@v6
       with:
-        name: tmp-cross-binaries-${{ matrix.target }}
-        path: .
+        result-encoding: string
+        retries: 3
+        retry-exempt-status-codes: 400,401
+        script: |
+          github.rest.actions.listWorkflowRunArtifacts({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            run_id: github.run_id,
+          });
   
     - name: Untar the set of downloaded binaries
       if: ${{ matrix.target != 'x86_64' }}

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -756,7 +756,7 @@ jobs:
 
     - name: Download cross compiled binaries
       if: ${{ matrix.target != 'x86_64' }}
-      uses: Wandelen/wretry.action@v1
+      uses: Wandalen/wretry.action@v1.0.36
       with:
         action: actions/download-artifact@v3
         with: |

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -531,7 +531,7 @@ jobs:
   #
   # See: https://github.com/rust-embedded/cross#docker-in-docker
   cross:
-    name: cross
+    name: cross-${{ matrix.target }}
     if: ${{ needs.prepare.outputs.cross_build_rules != '{}' }}
     needs: prepare
     runs-on: ubuntu-20.04
@@ -760,7 +760,7 @@ jobs:
       uses: yogeshlonkar/wait-for-jobs@v0
       with:
         gh-token: ${{ secrets.GITHUB_TOKEN }}
-        jobs: cross
+        jobs: cross-${{ matrix.target }}
         interval: 30000
         ttl: 10
 

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -1397,7 +1397,7 @@ jobs:
   docker:
     # Use of always() here ensures that even if the cross job is skipped we will still run
     if: ${{ always() && needs.prepare.outputs.docker_build_rules != '{}' }}
-    needs: [cross, prepare]
+    needs: prepare
     outputs:
       published: ${{ steps.publish.conclusion == 'success' }}
     runs-on: ubuntu-20.04
@@ -1459,6 +1459,8 @@ jobs:
           # Note: matrix.platform here has to match the Docker BuildX $TARGETPLATFORM variable available while building
           # the Dockerfile, e.g. linux/amd64.
           path: dockerbin/${{ matrix.platform }}
+          maxTries: 20
+          retryDelayMs: 30000
 
       - name: Untar the set of downloaded binaries
         if: ${{ steps.verify.outputs.mode == 'copy' }}

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -755,6 +755,7 @@ jobs:
         esac
 
     - name: Wait for cross-compilation
+      id: waitcross
       if: ${{ matrix.target != 'x86_64' }}
       uses: actions/github-script@v6
       with:
@@ -762,11 +763,15 @@ jobs:
         retries: 3
         retry-exempt-status-codes: 400,401
         script: |
-          console.log(github.rest.actions.listWorkflowRunArtifacts({
+          github.rest.actions.listWorkflowRunArtifacts({
             owner: context.repo.owner,
             repo: context.repo.repo,
             run_id: ${{ github.run_id }},
-          }));
+          });
+
+    - name: Debug
+      if: ${{ matrix.target != 'x86_64' }}
+      run: echo "${{steps.waitcross.outputs.result}}"
 
     - name: Download cross-compiled binaries
       if: ${{ matrix.target != 'x86_64' }}

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -531,6 +531,7 @@ jobs:
   #
   # See: https://github.com/rust-embedded/cross#docker-in-docker
   cross:
+    name: cross
     if: ${{ needs.prepare.outputs.cross_build_rules != '{}' }}
     needs: prepare
     runs-on: ubuntu-20.04
@@ -759,7 +760,7 @@ jobs:
       uses: yogeshlonkar/wait-for-jobs@v0
       with:
         gh-token: ${{ secrets.GITHUB_TOKEN }}
-        jobs: cross (${{ matrix.target }})
+        jobs: cross
         interval: 30000
         ttl: 10
 

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -555,6 +555,9 @@ jobs:
       run: |
         cargo install cross
 
+    - name: Go slow while testing
+      run: sleep 75s
+
     - name: Cross compile
       run: |
         cross build --locked --release -v --target ${{ matrix.target }} ${{ inputs.cross_build_args }}

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -357,8 +357,9 @@ jobs:
           echo 'END_OF_TARGETS' >> $GITHUB_OUTPUT
 
           RETRY_DELAY_MS=30000
-          echo "retry_delay_ms=${RETRY_DELAY_MS}"
-          echo "max_wait_ms=" $(( ( ${{ inputs.cross_max_wait_mins }} * 60 * 1000) / ${RETRY_DELAY_MS} ))
+          MAX_WAIT_MS=$(( ( ${{ inputs.cross_max_wait_mins }} * 60 * 1000 ) / ${RETRY_DELAY_MS} ))
+          echo "retry_delay_ms=${RETRY_DELAY_MS}" >> $GITHUB_OUTPUT
+          echo "max_wait_ms=${MAX_WAIT_MS}" >> $GITHUB_OUTPUT
 
       - name: Print rules
         # Disable default use of bash -x for easier to read output in the log

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -690,8 +690,8 @@ jobs:
       run: |
         case ${OS_NAME} in
           debian|ubuntu)
-            apt-get install -y gnupg 
-            echo "deb http://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null
+            apt-get install -y apt-transport-https gnupg 
+            echo "deb https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null
             curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=./githubcli-archive-keyring.gpg
             apt-key add ./githubcli-archive-keyring.gpg
             apt-get update

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -760,7 +760,7 @@ jobs:
 
     - name: Download cross-compiled binaries
       if: ${{ matrix.target != 'x86_64' }}
-      uses: ximon18/download-artifact@testing
+      uses: ximon18/download-artifact@v3
       with:
         name: tmp-cross-binaries-${{ matrix.target }}
         path: .

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -754,28 +754,11 @@ jobs:
             ;;
         esac
 
-    - name: Sleep
-      uses: juliangruber/sleep-action@v1
-      with:
-        time: 120s
-
     - name: Wait for cross-compilation
-      id: waitcross
-      if: ${{ matrix.target != 'x86_64' }}
-      uses: actions/github-script@v6
+      uses: yogeshlonkar/wait-for-jobs@v0
       with:
-        retries: 3
-        retry-exempt-status-codes: 400,401
-        script: |
-          github.rest.actions.listWorkflowRunArtifacts({
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            run_id: ${{ github.run_id }},
-          });
-
-    - name: Debug
-      if: ${{ matrix.target != 'x86_64' }}
-      run: echo "${{steps.waitcross.outputs.result}}"
+        gh-token: ${{ secrets.GITHUB_TOKEN }}
+        jobs: cross
 
     - name: Download cross-compiled binaries
       if: ${{ matrix.target != 'x86_64' }}

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -692,7 +692,7 @@ jobs:
           debian|ubuntu)
             curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
             chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg
-            echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null
+            echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] http://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null
             apt-get update
             apt-get install -y binutils dpkg-dev gcc gh jq lintian pkg-config ${{ inputs.deb_extra_build_packages }}
             ;;
@@ -700,7 +700,7 @@ jobs:
             sed -i -e 's/enabled=1/enabled=0/' /etc/yum/pluginconf.d/fastestmirror.conf || true
             yum install epel-release -y
             yum install 'dnf-command(config-manager)'
-            yum config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo
+            yum config-manager --add-repo http://cli.github.com/packages/rpm/gh-cli.repo
             yum install -y findutils gcc gh jq rpmlint ${{ inputs.rpm_extra_build_packages }}
             ;;
         esac

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -759,7 +759,6 @@ jobs:
       if: ${{ matrix.target != 'x86_64' }}
       uses: actions/github-script@v6
       with:
-        result-encoding: string
         retries: 3
         retry-exempt-status-codes: 400,401
         script: |

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -1457,7 +1457,7 @@ jobs:
 
       - uses: docker/setup-buildx-action@v2
 
-      - name: Download cross compiled binaries
+      - name: Download cross-compiled binaries
         if: ${{ steps.verify.outputs.mode == 'copy' }}
         uses: ximon18/download-artifact@v3
         with:

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -760,7 +760,7 @@ jobs:
 
     - name: Download cross-compiled binaries
       if: ${{ matrix.target != 'x86_64' }}
-      uses: ximon18/download-artifact@testing
+      uses: ximon18/download-artifact@a76002bf051c84e958e35e7f526f6f6e1b6f6e01
       with:
         name: tmp-cross-binaries-${{ matrix.target }}
         path: .

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -283,7 +283,7 @@ jobs:
       first_repo_and_tag_pair: ${{ steps.encode.outputs.first_repo_and_tag_pair }}
       lower_docker_org: ${{ steps.encode.outputs.lower_docker_org }}
       cross_build_rules: ${{ steps.determine_cross_build_rules.outputs.matrix }}
-      cross_max_wait_ms: ${{ steps.determine_cross_build_rules.outputs.max_wait_ms }}
+      cross_max_tries: ${{ steps.determine_cross_build_rules.outputs.max_tries }}
       cross_retry_delay_ms: ${{ steps.determine_cross_build_rules.outputs.retry_delay_ms }}
       docker_build_rules: ${{ steps.pre_process_rules.outputs.docker_build_rules }}
       package_build_rules: ${{ steps.pre_process_rules.outputs.package_build_rules }}
@@ -357,9 +357,9 @@ jobs:
           echo 'END_OF_TARGETS' >> $GITHUB_OUTPUT
 
           RETRY_DELAY_MS=30000
-          MAX_WAIT_MS=$(( ( ${{ inputs.cross_max_wait_mins }} * 60 * 1000 ) / ${RETRY_DELAY_MS} ))
+          MAX_TRIES=$(( ( ${{ inputs.cross_max_wait_mins }} * 60 * 1000 ) / ${RETRY_DELAY_MS} ))
           echo "retry_delay_ms=${RETRY_DELAY_MS}" >> $GITHUB_OUTPUT
-          echo "max_wait_ms=${MAX_WAIT_MS}" >> $GITHUB_OUTPUT
+          echo "max_tries=${MAX_TRIES}" >> $GITHUB_OUTPUT
 
       - name: Print rules
         # Disable default use of bash -x for easier to read output in the log
@@ -776,7 +776,7 @@ jobs:
       with:
         name: tmp-cross-binaries-${{ matrix.target }}
         path: .
-        maxTries: ${{ needs.prepare.outputs.cross_max_wait_ms }}
+        maxTries: ${{ needs.prepare.outputs.cross_max_tries }}
         retryDelayMs: ${{ needs.prepare.outputs.cross_retry_delay_ms }}
   
     - name: Untar the set of downloaded binaries
@@ -1471,7 +1471,7 @@ jobs:
           # Note: matrix.platform here has to match the Docker BuildX $TARGETPLATFORM variable available while building
           # the Dockerfile, e.g. linux/amd64.
           path: dockerbin/${{ matrix.platform }}
-          maxTries: ${{ needs.prepare.outputs.cross_max_wait_ms }}
+          maxTries: ${{ needs.prepare.outputs.cross_max_tries }}
           retryDelayMs: ${{ needs.prepare.outputs.cross_retry_delay_ms }}
 
       - name: Untar the set of downloaded binaries

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -759,7 +759,7 @@ jobs:
       uses: yogeshlonkar/wait-for-jobs@v0
       with:
         gh-token: ${{ secrets.GITHUB_TOKEN }}
-        jobs: cross
+        jobs: cross (${{ matrix.target }})
         interval: 30000
         ttl: 10
 

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -690,12 +690,12 @@ jobs:
       run: |
         case ${OS_NAME} in
           debian|ubuntu)
-            apt-get install -y binutils gcc dpkg-dev git jq lintian pkg-config ${{ inputs.deb_extra_build_packages }}
+            apt-get install -y binutils gcc dpkg-dev jq lintian pkg-config ${{ inputs.deb_extra_build_packages }}
             ;;
           centos)
             sed -i -e 's/enabled=1/enabled=0/' /etc/yum/pluginconf.d/fastestmirror.conf || true
             yum install epel-release -y
-            yum install -y findutils gcc git jq rpmlint ${{ inputs.rpm_extra_build_packages }}
+            yum install -y findutils gcc jq rpmlint ${{ inputs.rpm_extra_build_packages }}
             ;;
         esac
 
@@ -754,16 +754,24 @@ jobs:
             ;;
         esac
 
+    - name: Wait for cross compilation
+      if: ${{ matrix.target != 'x86_64' }}
+      run: |
+        MAX_RETRIES=120
+        DELAY_SECS=5
+        RETRY_N=1
+        while [ $RETRY_N -lt $MAX_RETRIES ]; do
+          gh run download ${{ github.run_id }} --name tmp-cross-binaries-${{ matrix.target }} && exit 0
+          RETRY_N=$(( $RETRY_N + 1 ))
+          sleep $DELAY_SECS
+        done
+        exit 1
+
     - name: Download cross compiled binaries
       if: ${{ matrix.target != 'x86_64' }}
-      uses: Wandalen/wretry.action@v1.0.36
       with:
-        action: actions/download-artifact@v3
-        with: |
-          name: tmp-cross-binaries-${{ matrix.target }}
-          path: .
-        attempt_limit: 120
-        attempt_delay: 5000
+        name: tmp-cross-binaries-${{ matrix.target }}
+        path: .
   
     - name: Untar the set of downloaded binaries
       if: ${{ matrix.target != 'x86_64' }}


### PR DESCRIPTION
Prior to this PR, the `pkg` and `docker` jobs cannot start until the `cross` job has completed, even if most of the work to  be done in the blocked jobs is not dependent on the `cross` job. Also, permutations of the `pkg`/`docker` jobs that do depend on the `cross` job complete very quickly because the compilation was already done by the `cross` job, but the majority of the permutations are non-cross and don't _start_ the long slow compiling process until the `cross` job completes. This is very inefficient.

An early attempt a while ago to solve this using `lewagon/wait-on-check-action` was abandoned due to it being fragile, sometimes it worked but other times it would stop waiting even though the wait condition was not yet met.

Early versions of this PR tried various approaches to solve this issue which also all failed:
- Using the `Wandelen/wretry.action` action - didn't work because the action expects to run on the GH runner host, not in a container and calls out to binaries that don't exist (e.g. `git`) in the Docker image being used to do compilation.
- Using the GH CLI to download artifacts and retry if not existing - didn't work because the artifacts uploaded by the `cross` job are never found.
- Using `actions/github-script` to download artifacts via the `listWorkflowRunArtifacts()` call to the GH API and retry if not existing - didn't work because the artifacts uploaded by the `cross` job are never found.
- Using the `yogeshlonkar/wait-for-jobs` action - didn't work because the job could not be found by name, presumably it only supports non-matrix jobs or I didn't find the right magic incantation of combination of naming the job and passing the job name to match on.

I then looked closely at the source code of `actions/download-artifact` to find out why it CAN see the `cross` job uploaded artifacts but other actions and uses of the API do not, and discovered that it does NOT call the GH Actions API, rather it calls an Azure Pipeline API. I suspect the GH Actions API is a layer on top of Azure Pipelines and the GH Actions API doesn't see artifacts uploaded inter-job, it only sees them once the workflow completes (which also explains why artifacts don't appear on the workflow run summary page until the workflow completes).

I didn't find a way to retry the action, so I forked it and added a retry with delay to it myself. See https://github.com/ximon18/download-artifact/pull/1, and this PR now uses that fork.

An alternate approach of incorporating the `cross` job cross-compilation into the `pkg` and `docker` jobs isn't possible/easy because the Rust `cross` tool has issues when run docker-in-docker (and didn't work when I tried it), as would be the case if invoked from the `pkg` job, and compilation and packaging in the DEB case are hard to separate because `cargo-deb` does both itself (we could stop it compiling and do it ourselves but that might not make the best use of cargo-debs abilities then).

Hence where this PR finds itself now. In this PR the `cross` job runs parallel to, instead of before, the `pkg` and `docker` jobs. In those jobs the download cross-compiled binaries step uses the forked `ximon18/download-artifact` action to keep trying to download the cross-compiled artifact until it appears and can be downloaded, or until a maximum number of retries is reached. Download attempts are done every 30 seconds because doing it more often causes more API calls which, if often enough, could cause us to hit the API rate limit and then our account gets blocked for an hour which we don't want .... !